### PR TITLE
Remove path duplication which causes problems on OSX

### DIFF
--- a/src/ess/v20/imaging/helper_funcs.py
+++ b/src/ess/v20/imaging/helper_funcs.py
@@ -53,7 +53,7 @@ def _load_images(image_dir, extension, loader):
         print('\r{0}: Image {1}, of {2}'.format(filename[path_length:], count,
                                                 nfiles),
               end="")
-        img = loader(os.path.join(image_dir, filename))
+        img = loader(filename)
         stack.append(np.flipud(img.data))
 
     print()  # Print a newline to separate each load message


### PR DESCRIPTION
There seems to be a path duplication here as `glob` will already return the full filename.
On linux, the `image_dir` and `filename` were,
```
/media/nvaytet/Data/ess-notebooks-data/ess/v20/imaging/gp2-stress-experiments/R825-open-beam
```
and
```
/media/nvaytet/Data/ess-notebooks-data/ess/v20/imaging/gp2-stress-experiments/R825-open-beam/GP2_034_Open_Beam0000.tiff
```
respectively.

On OSX, we were getting something like
```
/Users/username/Data/WFM_scipp/ess-notebooks-data/ess/v20/imaging/gp2-stress-experiments/R825-open-beam/
```
and
```
ess-notebooks-data/ess/v20/imaging/gp2-stress-experiments/R825-open-beam/GP2_034_Open_Beam0000.tiff
```
where the subsequent `os.path.join` would generate a bad file name because of the prepended `/Users/username/Data/WFM_scipp/`