### PR TITLE
Load Component Info

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -19,6 +19,7 @@ requirements:
     - scipy
     - matplotlib
     - ipywidgets
+    - scipy
 
 test:
   imports:

--- a/ess-developer.yml
+++ b/ess-developer.yml
@@ -6,7 +6,7 @@ channels:
   - nodefaults
 
 dependencies:
-  - scippneutron=0.2.1
+  - scippneutron
   - mantid-framework
   - pytest
   - sphinx>=1.6
@@ -14,7 +14,7 @@ dependencies:
   - tifffile
   - astropy 
   - matplotlib
-  - python=3.7
+  - python
   - ipywidgets
   # For developement
   - pytest

--- a/ess-developer.yml
+++ b/ess-developer.yml
@@ -6,7 +6,7 @@ channels:
   - nodefaults
 
 dependencies:
-  - scippneutron
+  - scippneutron=0.2.1
   - mantid-framework
   - pytest
   - sphinx>=1.6
@@ -14,7 +14,7 @@ dependencies:
   - tifffile
   - astropy 
   - matplotlib
-  - python
+  - python=3.7
   - ipywidgets
   # For developement
   - pytest

--- a/ess-developer.yml
+++ b/ess-developer.yml
@@ -16,6 +16,7 @@ dependencies:
   - matplotlib
   - python
   - ipywidgets
+  - scipy
   # For developement
   - pytest
   - ipython

--- a/ess-stable.yml
+++ b/ess-stable.yml
@@ -16,3 +16,4 @@ dependencies:
   - python
   - gitpython
   - ipywidgets
+  - scipy

--- a/ess-stable.yml
+++ b/ess-stable.yml
@@ -7,7 +7,6 @@ channels:
 
 dependencies:
   - scippneutron=0.2
-  - mantid-framework
   - pytest
   - sphinx>=1.6
   - sphinx_rtd_theme

--- a/src/ess/imaging/mantid.py
+++ b/src/ess/imaging/mantid.py
@@ -1,0 +1,43 @@
+import scippneutron as scn
+import scipp as sc
+import numpy as np
+
+
+def load_component_info_to_2d(geometry_file, advanced_geometry=False):
+    """Load geometry information from a mantid Instrument Definition File
+        or a NeXuS file containing instrument geometry. and reshape into 2D
+        physical dimensions.
+
+        This function requires mantid-framework to be installed
+
+        :param geometry_file: IDF or NeXus file
+        :return dictionary of component names to positions,
+            rotations and shapes
+        :raises ImportError if mantid cannot be imported
+        """
+    from mantid.simpleapi import LoadEmptyInstrument
+    ws = LoadEmptyInstrument(Filename=geometry_file, StoreInADS=False)
+    source_pos, sample_pos = scn.mantid.make_component_info(ws)
+    geometry = {}
+    geometry["source_position"] = source_pos
+    geometry["sample_position"] = sample_pos
+    print(source_pos)
+    print(sample_pos)
+    pos, rot, shp = scn.mantid.get_detector_properties(
+        ws,
+        source_pos,
+        sample_pos,
+        spectrum_dim='spectrum',
+        advanced_geometry=advanced_geometry)
+    x = int(np.sqrt(pos.shape[0]))
+    pos2d = sc.fold(pos, dim='spectrum', dims=['y', 'x'], shape=[x, x])
+    geometry["position"] = pos2d
+    if rot is not None:
+        rot2d = sc.fold(rot, dim='spectrum', dims=['y', 'x'], shape=[x, x])
+        geometry["rotation"] = rot2d
+    if shp is not None:
+        shp2d = sc.fold(shp, dim='spectrum', dims=['y', 'x'], shape=[x, x])
+        geometry["shape"] = shp2d
+    geometry["x"] = pos2d.fields.x['y', 0]
+    geometry["y"] = pos2d.fields.y['x', 0]
+    return geometry

--- a/src/ess/imaging/mantid.py
+++ b/src/ess/imaging/mantid.py
@@ -13,14 +13,15 @@ def load_component_info_to_2d(geometry_file, sizes, advanced_geometry=False):
 
         :param geometry_file: IDF or NeXus file
         :param sizes: Dict of dim to size for output
-        :return dictionary of component names to positions,
+        :return Dataset containing items for positions,
             rotations and shapes
         :raises ImportError if mantid cannot be imported
+        :raises ValueError if sizes argument invalid
         """
     from mantid.simpleapi import LoadEmptyInstrument
     ws = LoadEmptyInstrument(Filename=geometry_file, StoreInADS=False)
     source_pos, sample_pos = scn.mantid.make_component_info(ws)
-    geometry = {}
+    geometry = sc.Dataset()
     geometry["source_position"] = source_pos
     geometry["sample_position"] = sample_pos
     pos, rot, shp = scn.mantid.get_detector_properties(

--- a/src/ess/imaging/mantid.py
+++ b/src/ess/imaging/mantid.py
@@ -49,6 +49,9 @@ def load_component_info_to_2d(geometry_file, sizes, advanced_geometry=False):
     if shp is not None:
         shp2d = sc.fold(shp, **fold_args)
         geometry["shape"] = shp2d
-    for u, v in zip(sizes.keys(), reversed(list(sizes.keys()))):
-        geometry[u] = pos2d.fields.x[v, 0]
+    # Could be upgraded, but logic complex for mapping to fields of vector
+    # We therefore limit the element coord generation to x, y, z only
+    if set(sizes.keys()).issubset({'x', 'y', 'z'}):
+        for u, v in zip(sizes.keys(), reversed(list(sizes.keys()))):
+            geometry[u] = getattr(pos2d.fields, u)[v, 0]
     return geometry

--- a/tests/imaging/mantid_test.py
+++ b/tests/imaging/mantid_test.py
@@ -7,6 +7,7 @@ import pytest
 @pytest.fixture(scope="module")
 def geom_file():
     import mantid.simpleapi as sapi
+    # 100 output positions (10 by 10)
     ws = sapi.CreateSampleWorkspace(NumBanks=1,
                                     BankPixelWidth=10,
                                     StoreInADS=False)
@@ -21,14 +22,45 @@ def geom_file():
         pass
 
 
+def test_load_component_info_to_2d_geometry_bad_sizes(geom_file):
+    bad_sizes = {'x': 10, 'y': 5}  # gives volume of 50 not 100
+    with pytest.raises(ValueError):
+        mantid.load_component_info_to_2d(geom_file, sizes=bad_sizes)
+
+
 def test_load_component_info_to_2d_geometry(geom_file):
     geometry = mantid.load_component_info_to_2d(geom_file,
-                                                advanced_geometry=False)
+                                                sizes={
+                                                    'x': 10,
+                                                    'y': 10
+                                                })
     assert geometry["position"].sizes == {'x': 10, 'y': 10}
+
+
+def test_load_component_info_to_2d_geometry_irregular(geom_file):
+    geometry = mantid.load_component_info_to_2d(geom_file,
+                                                sizes={
+                                                    'y': 2,
+                                                    'x': 50
+                                                })
+    assert geometry["position"].sizes == {'x': 50, 'y': 2}
+
+
+def test_load_component_info_to_2d_geometry_with_specified_keys(geom_file):
+    geometry = mantid.load_component_info_to_2d(geom_file,
+                                                sizes={
+                                                    'u': 10,
+                                                    'v': 10
+                                                })
+    assert geometry["position"].sizes == {'u': 10, 'v': 10}
 
 
 def test_load_component_info_to_2d_geometry_advanced_geom(geom_file):
     geometry = mantid.load_component_info_to_2d(geom_file,
+                                                sizes={
+                                                    'x': 10,
+                                                    'y': 10
+                                                },
                                                 advanced_geometry=True)
     assert geometry["position"].sizes == {'x': 10, 'y': 10}
     assert geometry["rotation"].sizes == {'x': 10, 'y': 10}

--- a/tests/imaging/mantid_test.py
+++ b/tests/imaging/mantid_test.py
@@ -54,12 +54,12 @@ def test_load_component_info_to_2d_geometry(geom_file):
     assert geometry["position"].sizes == {'x': 10, 'y': 10}
     assert sc.identical(
         geometry["x"],
-        sc.array(dims=["x"], values=np.arange(0.0, 0.1, 0.01),
-                 unit=sc.units.m))
+        sc.DataArray(data=sc.array(
+            dims=["x"], values=np.arange(0.0, 0.1, 0.01), unit=sc.units.m)))
     assert sc.identical(
         geometry["y"],
-        sc.array(dims=["y"], values=np.arange(0.0, 0.1, 0.01),
-                 unit=sc.units.m))
+        sc.DataArray(data=sc.array(
+            dims=["y"], values=np.arange(0.0, 0.1, 0.01), unit=sc.units.m)))
 
 
 @with_mantid_only

--- a/tests/imaging/mantid_test.py
+++ b/tests/imaging/mantid_test.py
@@ -18,7 +18,7 @@ def geom_file():
     yield geom_path
     try:
         os.remove(geom_path)
-    except:
+    except Exception:
         pass
 
 

--- a/tests/imaging/mantid_test.py
+++ b/tests/imaging/mantid_test.py
@@ -1,0 +1,35 @@
+from ess.imaging import mantid
+import tempfile
+import os
+import pytest
+
+
+@pytest.fixture(scope="module")
+def geom_file():
+    import mantid.simpleapi as sapi
+    ws = sapi.CreateSampleWorkspace(NumBanks=1,
+                                    BankPixelWidth=10,
+                                    StoreInADS=False)
+    file_name = "example_geometry.nxs"
+    geom_path = os.path.join(tempfile.gettempdir(), file_name)
+    sapi.SaveNexusGeometry(ws, geom_path)
+    assert os.path.isfile(geom_path)  # sanity check
+    yield geom_path
+    try:
+        os.remove(geom_path)
+    except:
+        pass
+
+
+def test_load_component_info_to_2d_geometry(geom_file):
+    geometry = mantid.load_component_info_to_2d(geom_file,
+                                                advanced_geometry=False)
+    assert geometry["position"].sizes == {'x': 10, 'y': 10}
+
+
+def test_load_component_info_to_2d_geometry_advanced_geom(geom_file):
+    geometry = mantid.load_component_info_to_2d(geom_file,
+                                                advanced_geometry=True)
+    assert geometry["position"].sizes == {'x': 10, 'y': 10}
+    assert geometry["rotation"].sizes == {'x': 10, 'y': 10}
+    assert geometry["shape"].sizes == {'x': 10, 'y': 10}

--- a/tests/imaging/mantid_test.py
+++ b/tests/imaging/mantid_test.py
@@ -4,6 +4,18 @@ import os
 import pytest
 
 
+def mantid_is_available():
+    try:
+        import mantid  # noqa: F401
+        return True
+    except ModuleNotFoundError:
+        return False
+
+
+with_mantid_only = pytest.mark.skipif(not mantid_is_available(),
+                                      reason='Mantid framework is unavailable')
+
+
 @pytest.fixture(scope="module")
 def geom_file():
     import mantid.simpleapi as sapi
@@ -22,12 +34,14 @@ def geom_file():
         pass
 
 
+@with_mantid_only
 def test_load_component_info_to_2d_geometry_bad_sizes(geom_file):
     bad_sizes = {'x': 10, 'y': 5}  # gives volume of 50 not 100
     with pytest.raises(ValueError):
         mantid.load_component_info_to_2d(geom_file, sizes=bad_sizes)
 
 
+@with_mantid_only
 def test_load_component_info_to_2d_geometry(geom_file):
     geometry = mantid.load_component_info_to_2d(geom_file,
                                                 sizes={
@@ -37,6 +51,7 @@ def test_load_component_info_to_2d_geometry(geom_file):
     assert geometry["position"].sizes == {'x': 10, 'y': 10}
 
 
+@with_mantid_only
 def test_load_component_info_to_2d_geometry_irregular(geom_file):
     geometry = mantid.load_component_info_to_2d(geom_file,
                                                 sizes={
@@ -46,6 +61,7 @@ def test_load_component_info_to_2d_geometry_irregular(geom_file):
     assert geometry["position"].sizes == {'x': 50, 'y': 2}
 
 
+@with_mantid_only
 def test_load_component_info_to_2d_geometry_with_specified_keys(geom_file):
     geometry = mantid.load_component_info_to_2d(geom_file,
                                                 sizes={
@@ -55,6 +71,7 @@ def test_load_component_info_to_2d_geometry_with_specified_keys(geom_file):
     assert geometry["position"].sizes == {'u': 10, 'v': 10}
 
 
+@with_mantid_only
 def test_load_component_info_to_2d_geometry_advanced_geom(geom_file):
     geometry = mantid.load_component_info_to_2d(geom_file,
                                                 sizes={


### PR DESCRIPTION
Fixes #30 

* Loads component information and returns as a `dict`
* Allows reshaping to any 2D (including differing extents) dims (volume preserving must apply)
* Sanity checks inputs including volume
