### PR TITLE
Tests leave un-versioned orphaned files

### DIFF
--- a/tests/amor/__init__.py
+++ b/tests/amor/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2021 Scipp contributors (https://github.com/scipp)

--- a/tests/amor/amor_data_test.py
+++ b/tests/amor/amor_data_test.py
@@ -13,6 +13,7 @@ import numpy as np
 from numpy.testing import assert_almost_equal, assert_equal
 import scipp as sc
 from ess.amor import amor_data
+from ..tools.io import file_location
 
 np.random.seed(1)
 
@@ -271,12 +272,10 @@ class TestNormalisation(unittest.TestCase):
                                               values=DETECTORS.astype(float),
                                               unit=sc.units.deg)
         z = amor_data.Normalisation(p, q)
-        file_path = (os.path.dirname(os.path.realpath(__file__)) +
-                     os.path.sep + "test1.txt")
-        z.write_reflectometry(file_path)
-        written_data = np.loadtxt(file_path, unpack=True)
-        assert_equal(written_data.shape, (4, 199))
-        os.remove(file_path)
+        with file_location("test1.txt") as file_path:
+            z.write_reflectometry(file_path)
+            written_data = np.loadtxt(file_path, unpack=True)
+            assert_equal(written_data.shape, (4, 199))
 
     def test_binwavelength_theta_norm(self):
         p = amor_data.AmorData(BINNED.copy())
@@ -318,10 +317,8 @@ class TestNormalisation(unittest.TestCase):
                                               values=DETECTORS.astype(float),
                                               unit=sc.units.deg)
         z = amor_data.Normalisation(p, q)
-        file_path = (os.path.dirname(os.path.realpath(__file__)) +
-                     os.path.sep + "test1.txt")
-        bins = np.linspace(0, 100, 10)
-        z.write_wavelength_theta(file_path, (bins, bins))
-        written_data = np.loadtxt(file_path, unpack=True)
-        assert_equal(written_data.shape, (11, 9))
-        os.remove(file_path)
+        with file_location("test1.txt") as file_path:
+            bins = np.linspace(0, 100, 10)
+            z.write_wavelength_theta(file_path, (bins, bins))
+            written_data = np.loadtxt(file_path, unpack=True)
+            assert_equal(written_data.shape, (11, 9))

--- a/tests/amor/amor_data_test.py
+++ b/tests/amor/amor_data_test.py
@@ -276,6 +276,7 @@ class TestNormalisation(unittest.TestCase):
         z.write_reflectometry(file_path)
         written_data = np.loadtxt(file_path, unpack=True)
         assert_equal(written_data.shape, (4, 199))
+        os.remove(file_path)
 
     def test_binwavelength_theta_norm(self):
         p = amor_data.AmorData(BINNED.copy())
@@ -323,3 +324,4 @@ class TestNormalisation(unittest.TestCase):
         z.write_wavelength_theta(file_path, (bins, bins))
         written_data = np.loadtxt(file_path, unpack=True)
         assert_equal(written_data.shape, (11, 9))
+        os.remove(file_path)

--- a/tests/reflectometry/data_test.py
+++ b/tests/reflectometry/data_test.py
@@ -13,6 +13,7 @@ import numpy as np
 from numpy.testing import assert_almost_equal, assert_equal
 import scipp as sc
 from ess.reflectometry import data
+from ..tools.io import file_location
 
 np.random.seed(1)
 
@@ -643,12 +644,10 @@ class TestData(unittest.TestCase):
             dtype=sc.dtype.float64,
         )
         p.event.coords["tof"] = sc.Variable(dims=["event"], values=DETECTORS)
-        file_path = (os.path.dirname(os.path.realpath(__file__)) +
-                     os.path.sep + "test1.txt")
-        p.write_reflectometry(file_path)
-        written_data = np.loadtxt(file_path, unpack=True)
-        assert_equal(written_data.shape, (4, 199))
-        os.remove(file_path)
+        with file_location("test1.txt") as file_path:
+            p.write_reflectometry(file_path)
+            written_data = np.loadtxt(file_path, unpack=True)
+            assert_equal(written_data.shape, (4, 199))
 
     def test_write_bins(self):
         p = data.ReflData(BINNED.copy())
@@ -665,15 +664,14 @@ class TestData(unittest.TestCase):
         )
         p.event.coords["tof"] = sc.Variable(dims=["event"], values=DETECTORS)
         bins = np.linspace(0, 11, 4)
-        file_path = (os.path.dirname(os.path.realpath(__file__)) +
-                     os.path.sep + "test2.txt")
-        p.write_reflectometry(file_path, {"bins": bins})
-        written_data = np.loadtxt(file_path, unpack=True)
-        assert_almost_equal(written_data[0], bins[:-1] + np.diff(bins))
-        assert_almost_equal(written_data[1], np.array([3, 3, 3]) / 9)
-        assert_almost_equal(written_data[2], np.sqrt(np.array([3, 3, 3]) / 81))
-        assert_almost_equal(written_data[3], np.linspace(0.325, 1.0, 3))
-        os.remove(file_path)
+        with file_location("test2.txt") as file_path:
+            p.write_reflectometry(file_path, {"bins": bins})
+            written_data = np.loadtxt(file_path, unpack=True)
+            assert_almost_equal(written_data[0], bins[:-1] + np.diff(bins))
+            assert_almost_equal(written_data[1], np.array([3, 3, 3]) / 9)
+            assert_almost_equal(written_data[2],
+                                np.sqrt(np.array([3, 3, 3]) / 81))
+            assert_almost_equal(written_data[3], np.linspace(0.325, 1.0, 3))
 
     def test_write_wavelength_theta(self):
         p = data.ReflData(BINNED.copy())
@@ -684,10 +682,8 @@ class TestData(unittest.TestCase):
         p.event.coords["theta"] = sc.Variable(dims=["event"],
                                               values=DETECTORS.astype(float),
                                               unit=sc.units.deg)
-        file_path = (os.path.dirname(os.path.realpath(__file__)) +
-                     os.path.sep + "test1.txt")
         bins = np.linspace(0, 100, 10)
-        p.write_wavelength_theta(file_path, (bins, bins))
-        written_data = np.loadtxt(file_path, unpack=True)
-        assert_equal(written_data.shape, (11, 9))
-        os.remove(file_path)
+        with file_location("test1.txt") as file_path:
+            p.write_wavelength_theta(file_path, (bins, bins))
+            written_data = np.loadtxt(file_path, unpack=True)
+            assert_equal(written_data.shape, (11, 9))

--- a/tests/reflectometry/data_test.py
+++ b/tests/reflectometry/data_test.py
@@ -648,6 +648,7 @@ class TestData(unittest.TestCase):
         p.write_reflectometry(file_path)
         written_data = np.loadtxt(file_path, unpack=True)
         assert_equal(written_data.shape, (4, 199))
+        os.remove(file_path)
 
     def test_write_bins(self):
         p = data.ReflData(BINNED.copy())
@@ -672,6 +673,7 @@ class TestData(unittest.TestCase):
         assert_almost_equal(written_data[1], np.array([3, 3, 3]) / 9)
         assert_almost_equal(written_data[2], np.sqrt(np.array([3, 3, 3]) / 81))
         assert_almost_equal(written_data[3], np.linspace(0.325, 1.0, 3))
+        os.remove(file_path)
 
     def test_write_wavelength_theta(self):
         p = data.ReflData(BINNED.copy())
@@ -688,3 +690,4 @@ class TestData(unittest.TestCase):
         p.write_wavelength_theta(file_path, (bins, bins))
         written_data = np.loadtxt(file_path, unpack=True)
         assert_equal(written_data.shape, (11, 9))
+        os.remove(file_path)

--- a/tests/reflectometry/write_test.py
+++ b/tests/reflectometry/write_test.py
@@ -120,6 +120,7 @@ class TestWrite(unittest.TestCase):
         f = open(file_path, 'r')
         assert_equal(f.readline(), '# hello\n')
         f.close()
+        os.remove(file_path)
 
     def test_write_wavelength_theta(self):
         p = data.ReflData(BINNED.copy())
@@ -136,6 +137,7 @@ class TestWrite(unittest.TestCase):
         write.wavelength_theta(p, file_path, (bins, bins))
         written_data = np.loadtxt(file_path, unpack=True)
         assert_equal(written_data.shape, (11, 9))
+        os.remove(file_path)
 
     def test_write_wavelength_theta_norm(self):
         p = data.ReflData(BINNED.copy())
@@ -161,6 +163,7 @@ class TestWrite(unittest.TestCase):
         write.wavelength_theta(z, file_path, (bins, bins), z.sample.orso)
         written_data = np.loadtxt(file_path, unpack=True)
         assert_equal(written_data.shape, (11, 9))
+        os.remove(file_path)
 
     def test_write_wavelength_theta_header(self):
         p = data.ReflData(BINNED.copy())
@@ -185,3 +188,4 @@ class TestWrite(unittest.TestCase):
             '# # ORSO reflectivity data file | 0.1 standard | YAML encoding | https://reflectometry.org\n'
         )
         f.close()
+        os.remove(file_path)

--- a/tests/reflectometry/write_test.py
+++ b/tests/reflectometry/write_test.py
@@ -14,6 +14,7 @@ from numpy.testing import assert_almost_equal, assert_equal
 import scipp as sc
 from ess.reflectometry import write, data, orso
 from ess.amor import amor_data
+from ..tools.io import file_location
 
 np.random.seed(1)
 
@@ -87,11 +88,10 @@ class TestWrite(unittest.TestCase):
         )
         p.event.coords["tof"] = sc.Variable(dims=["event"],
                                             values=DETECTORS.astype(float))
-        file_path = (os.path.dirname(os.path.realpath(__file__)) +
-                     os.path.sep + "test1.txt")
-        write.reflectometry(p, file_path)
-        written_data = np.loadtxt(file_path, unpack=True)
-        assert_equal(written_data.shape, (4, 199))
+        with file_location("test1.txt") as file_path:
+            write.reflectometry(p, file_path)
+            written_data = np.loadtxt(file_path, unpack=True)
+            assert_equal(written_data.shape, (4, 199))
 
     def test_write_bins(self):
         p = data.ReflData(BINNED.copy())
@@ -109,18 +109,17 @@ class TestWrite(unittest.TestCase):
         p.event.coords["tof"] = sc.Variable(dims=["event"],
                                             values=DETECTORS.astype(float))
         bins = np.linspace(0, 11, 4)
-        file_path = (os.path.dirname(os.path.realpath(__file__)) +
-                     os.path.sep + "test2.txt")
-        write.reflectometry(p, file_path, {"bins": bins}, 'hello')
-        written_data = np.loadtxt(file_path, unpack=True)
-        assert_almost_equal(written_data[0], bins[:-1] + np.diff(bins))
-        assert_almost_equal(written_data[1], np.array([3, 3, 3]) / 9)
-        assert_almost_equal(written_data[2], np.sqrt(np.array([3, 3, 3]) / 81))
-        assert_almost_equal(written_data[3], np.linspace(0.325, 1.0, 3))
-        f = open(file_path, 'r')
-        assert_equal(f.readline(), '# hello\n')
-        f.close()
-        os.remove(file_path)
+        with file_location("test2.txt") as file_path:
+            write.reflectometry(p, file_path, {"bins": bins}, 'hello')
+            written_data = np.loadtxt(file_path, unpack=True)
+            assert_almost_equal(written_data[0], bins[:-1] + np.diff(bins))
+            assert_almost_equal(written_data[1], np.array([3, 3, 3]) / 9)
+            assert_almost_equal(written_data[2],
+                                np.sqrt(np.array([3, 3, 3]) / 81))
+            assert_almost_equal(written_data[3], np.linspace(0.325, 1.0, 3))
+            f = open(file_path, 'r')
+            assert_equal(f.readline(), '# hello\n')
+            f.close()
 
     def test_write_wavelength_theta(self):
         p = data.ReflData(BINNED.copy())
@@ -131,13 +130,11 @@ class TestWrite(unittest.TestCase):
         p.event.coords["theta"] = sc.Variable(dims=["event"],
                                               values=DETECTORS.astype(float),
                                               unit=sc.units.deg)
-        file_path = (os.path.dirname(os.path.realpath(__file__)) +
-                     os.path.sep + "test1.txt")
-        bins = np.linspace(0, 100, 10)
-        write.wavelength_theta(p, file_path, (bins, bins))
-        written_data = np.loadtxt(file_path, unpack=True)
-        assert_equal(written_data.shape, (11, 9))
-        os.remove(file_path)
+        with file_location("test1.txt") as file_path:
+            bins = np.linspace(0, 100, 10)
+            write.wavelength_theta(p, file_path, (bins, bins))
+            written_data = np.loadtxt(file_path, unpack=True)
+            assert_equal(written_data.shape, (11, 9))
 
     def test_write_wavelength_theta_norm(self):
         p = data.ReflData(BINNED.copy())
@@ -157,13 +154,11 @@ class TestWrite(unittest.TestCase):
                                               values=DETECTORS.astype(float),
                                               unit=sc.units.deg)
         z = amor_data.Normalisation(p, q)
-        file_path = (os.path.dirname(os.path.realpath(__file__)) +
-                     os.path.sep + "test1.txt")
-        bins = np.linspace(0, 100, 10)
-        write.wavelength_theta(z, file_path, (bins, bins), z.sample.orso)
-        written_data = np.loadtxt(file_path, unpack=True)
-        assert_equal(written_data.shape, (11, 9))
-        os.remove(file_path)
+        with file_location("test1.txt") as file_path:
+            bins = np.linspace(0, 100, 10)
+            write.wavelength_theta(z, file_path, (bins, bins), z.sample.orso)
+            written_data = np.loadtxt(file_path, unpack=True)
+            assert_equal(written_data.shape, (11, 9))
 
     def test_write_wavelength_theta_header(self):
         p = data.ReflData(BINNED.copy())
@@ -174,18 +169,17 @@ class TestWrite(unittest.TestCase):
         p.event.coords["theta"] = sc.Variable(dims=["event"],
                                               values=DETECTORS.astype(float),
                                               unit=sc.units.deg)
-        file_path = (os.path.dirname(os.path.realpath(__file__)) +
-                     os.path.sep + "test1.txt")
-        bins = np.linspace(0, 100, 10)
-        write.wavelength_theta(
-            p, file_path, (bins, bins),
-            orso.Orso(orso.Creator(), orso.DataSource(), orso.Reduction(), []))
-        written_data = np.loadtxt(file_path, unpack=True)
-        assert_equal(written_data.shape, (11, 9))
-        f = open(file_path, 'r')
-        assert_equal(
-            f.readline(),
-            '# # ORSO reflectivity data file | 0.1 standard | YAML encoding | https://reflectometry.org\n'
-        )
-        f.close()
-        os.remove(file_path)
+        with file_location("test1.txt") as file_path:
+            bins = np.linspace(0, 100, 10)
+            write.wavelength_theta(
+                p, file_path, (bins, bins),
+                orso.Orso(orso.Creator(), orso.DataSource(), orso.Reduction(),
+                          []))
+            written_data = np.loadtxt(file_path, unpack=True)
+            assert_equal(written_data.shape, (11, 9))
+            f = open(file_path, 'r')
+            assert_equal(
+                f.readline(),
+                '# # ORSO reflectivity data file | 0.1 standard | YAML encoding | https://reflectometry.org\n'
+            )
+            f.close()

--- a/tests/tools/__init__.py
+++ b/tests/tools/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2021 Scipp contributors (https://github.com/scipp)

--- a/tests/tools/io.py
+++ b/tests/tools/io.py
@@ -1,0 +1,19 @@
+from contextlib import contextmanager
+import tempfile
+import os
+
+
+@contextmanager
+def file_location(file_name):
+    """
+    Make a file in a temp directory.
+    Attempts to remove the file
+    at that location following the end of the context.
+    """
+    tempdir = tempfile.gettempdir()
+    f = os.path.join(tempdir, file_name)
+    yield f
+    try:
+        os.remove(f)
+    except OSError:
+        pass


### PR DESCRIPTION
Certain tests make temporary files, which are not removed after test completion and show up in the git working directory

* Make files in temporary directory so they don't appear in the source tree
* Use contextmanager to create file and perform os clean-up if file made