### PR TITLE
SANS basics

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+per-file-ignores = __init__.py:F401

--- a/src/ess/sans/__init__.py
+++ b/src/ess/sans/__init__.py
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
 
-from .reduction import reduce_by_wavelength
+from .reduction import reduce_to_q

--- a/src/ess/sans/__init__.py
+++ b/src/ess/sans/__init__.py
@@ -1,2 +1,4 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
+
+from .reduction import reduce_by_wavelength

--- a/src/ess/sans/__init__.py
+++ b/src/ess/sans/__init__.py
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
 
-from .reduction import reduce_to_q
+from .reduction import reduce_to_q, simple_reducer, grouping_reducer

--- a/src/ess/sans/reduction.py
+++ b/src/ess/sans/reduction.py
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
+
+
+def reduce_by_wavelength(data, q_bins, groupby, wavelength_bands):
+    # TODO Backup of the coord is necessary until `convert` can keep original
+    wavelength = data.coords['wavelength']
+    data = sc.neutron.convert(data, 'wavelength', 'Q',
+                              out=data)  # TODO no gravity yet
+    data.coords['wavelength'] = wavelength
+    bands = None
+    for i in range(wavelength_bands.sizes['wavelength'] - 1):
+        low = wavelength_bands['wavelength', i]
+        high = wavelength_bands['wavelength', i + 1]
+        band = sc.histogram(data['wavelength', low:high], q_bins)
+        band = sc.groupby(band, group=groupby).sum('spectrum')
+        bands = sc.concatenate(bands, band,
+                               'wavelength') if bands is not None else band
+    bands.coords['wavelength'] = wavelength_bands
+    return bands

--- a/src/ess/sans/reduction.py
+++ b/src/ess/sans/reduction.py
@@ -1,19 +1,30 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
+import scipp as sc
 
 
-def reduce_by_wavelength(data, q_bins, groupby, wavelength_bands):
+def simple_reducer(*, dim):
+    return lambda x: sc.sum(x, dim=dim)
+
+
+def grouping_reducer(*, dim, group):
+    return lambda x: sc.groupby(x, group=group).sum(dim=dim)
+
+
+def reduce_to_q(data, *, q_bins, reducer, wavelength_bands=None):
     # TODO Backup of the coord is necessary until `convert` can keep original
     wavelength = data.coords['wavelength']
-    data = sc.neutron.convert(data, 'wavelength', 'Q',
-                              out=data)  # TODO no gravity yet
+    data = sc.neutron.convert(data, 'wavelength', 'Q', out=data)
+    if wavelength_bands is None:
+        data = sc.histogram(data, q_bins)
+        return reducer(data)
     data.coords['wavelength'] = wavelength
     bands = None
     for i in range(wavelength_bands.sizes['wavelength'] - 1):
         low = wavelength_bands['wavelength', i]
         high = wavelength_bands['wavelength', i + 1]
         band = sc.histogram(data['wavelength', low:high], q_bins)
-        band = sc.groupby(band, group=groupby).sum('spectrum')
+        band = reducer(band)
         bands = sc.concatenate(bands, band,
                                'wavelength') if bands is not None else band
     bands.coords['wavelength'] = wavelength_bands

--- a/src/ess/sans/reduction.py
+++ b/src/ess/sans/reduction.py
@@ -12,6 +12,10 @@ def grouping_reducer(*, dim, group):
 
 
 def reduce_to_q(data, *, q_bins, reducer, wavelength_bands=None):
+    """
+    Example:
+    >>> reduced = reduce_to_q(data, q_bins=q_bins, reducer=simple_reducer('spectrum'))
+    """
     # TODO Backup of the coord is necessary until `convert` can keep original
     wavelength = data.coords['wavelength']
     data = sc.neutron.convert(data, 'wavelength', 'Q', out=data)

--- a/src/ess/sans/reduction.py
+++ b/src/ess/sans/reduction.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
 import scipp as sc
+import scippneutron as scn
 
 
 def simple_reducer(*, dim):
@@ -18,7 +19,7 @@ def reduce_to_q(data, *, q_bins, reducer, wavelength_bands=None):
     """
     # TODO Backup of the coord is necessary until `convert` can keep original
     wavelength = data.coords['wavelength']
-    data = sc.neutron.convert(data, 'wavelength', 'Q', out=data)
+    data = scn.convert(data, 'wavelength', 'Q', out=data)
     if wavelength_bands is None:
         data = sc.histogram(data, q_bins)
         return reducer(data)

--- a/src/ess/sans/reduction.py
+++ b/src/ess/sans/reduction.py
@@ -15,7 +15,7 @@ def grouping_reducer(*, dim, group):
 def reduce_to_q(data, *, q_bins, reducer, wavelength_bands=None):
     """
     Example:
-    >>> reduced = reduce_to_q(data, q_bins=q_bins, reducer=simple_reducer('spectrum'))
+    >>> reduced = reduce_to_q(data, q_bins=q_bins, reducer=simple_reducer('spectrum'))  # noqa: E501
     """
     # TODO Backup of the coord is necessary until `convert` can keep original
     wavelength = data.coords['wavelength']

--- a/src/ess/sans/reduction.py
+++ b/src/ess/sans/reduction.py
@@ -19,7 +19,7 @@ def reduce_to_q(data, *, q_bins, reducer, wavelength_bands=None):
     """
     # TODO Backup of the coord is necessary until `convert` can keep original
     wavelength = data.coords['wavelength']
-    data = scn.convert(data, 'wavelength', 'Q', out=data)
+    data = scn.convert(data, 'wavelength', 'Q', scatter=True)
     if wavelength_bands is None:
         data = sc.histogram(data, q_bins)
         return reducer(data)


### PR DESCRIPTION
Moved and improved from `ess-legacy` repo.

- Combine reduction with and without wavelength bands.
- Avoid hard-coding reduction and grouping dimensions (previously `spectrum` and `layer`).
- Configurable reducer, to support summing all spectra, or summing in groups.
- Use label-based indexing instead of `make_slices` helper.
- Rename `reduce` to `reduce_to_q` since `reduce` shadows a builtin name. Open to better suggestions.

For now this is untried, this will be done as follow-ups when other components get moved.