### PR TITLE
Fix wfm frames calcuation when source position is not (0,0,0)

### DIFF
--- a/src/ess/v20/imaging/__init__.py
+++ b/src/ess/v20/imaging/__init__.py
@@ -1,12 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
-from .operations import mask_from_adj_pixels, \
-    mean_from_adj_pixels, median_from_adj_pixels
-from .helper_funcs import read_x_values, tiffs_to_variable, \
-    fits_to_variable, make_detector_groups, export_tiff_stack
+# flake8: noqa
 
-__all__ = [
-    "mask_from_adj_pixels", "mean_from_adj_pixels", "median_from_adj_pixels",
-    "read_x_values", "tiffs_to_variable", "fits_to_variable", "make_detector_groups",
-    "export_tiff_stack"
-]
+from .beamline import *
+from .helper_funcs import *
+from .operations import *

--- a/src/ess/v20/imaging/beamline.py
+++ b/src/ess/v20/imaging/beamline.py
@@ -11,7 +11,6 @@ def make_beamline() -> dict:
     Chopper opening angles taken from Woracek et al. (2016)
     https://doi.org/10.1016/j.nima.2016.09.034
 
-    The -18.45 offsets in position is because the source is located at -18.45m.
     The +15.0 increments added to the angles correspond to an offset between the
     zero angle and the chopper top-dead centre.
     """

--- a/src/ess/v20/imaging/beamline.py
+++ b/src/ess/v20/imaging/beamline.py
@@ -2,16 +2,16 @@
 # Copyright (c) 2021 Scipp contributors (https://github.com/scipp)
 import numpy as np
 import scipp as sc
-from ...wfm.beamline import Beamline
-from ...wfm.choppers import Chopper
+from ...wfm.choppers import Chopper, ChopperKind
 
 
-def make_beamline() -> Beamline:
+def make_beamline() -> dict:
     """
     V20 chopper cascade and component positions.
     Chopper opening angles taken from Woracek et al. (2016)
     https://doi.org/10.1016/j.nima.2016.09.034
 
+    The -18.45 offsets in position is because the source is located at -18.45m.
     The +15.0 increments added to the angles correspond to an offset between the
     zero angle and the chopper top-dead centre.
     """
@@ -24,7 +24,7 @@ def make_beamline() -> Beamline:
         Chopper(
             frequency=sc.scalar(70.0, unit=hz),
             phase=sc.scalar(47.10, unit='deg'),
-            position=sc.vector(value=[0, 0, 6.6], unit='m'),
+            position=sc.vector(value=[0, 0, 6.6 - 18.45], unit='m'),
             opening_angles_open=sc.array(
                 dims=[dim],
                 values=np.array([83.71, 140.49, 193.26, 242.32, 287.91, 330.3]) + 15.0,
@@ -32,25 +32,27 @@ def make_beamline() -> Beamline:
             opening_angles_close=sc.array(
                 dims=[dim],
                 values=np.array([94.7, 155.79, 212.56, 265.33, 314.37, 360.0]) + 15.0,
-                unit='deg')),
+                unit='deg'),
+            kind=ChopperKind.WFM),
         "WFMC2":
         Chopper(
             frequency=sc.scalar(70.0, unit=hz),
             phase=sc.scalar(76.76, unit='deg'),
-            position=sc.vector(value=[0, 0, 7.1], unit='m'),
+            position=sc.vector(value=[0, 0, 7.1 - 18.45], unit='m'),
             opening_angles_open=sc.array(
                 dims=[dim],
-                values=np.array([65.04, 126.1, 182.88, 235.67, 284.73, 330.00]) + 15.0,
+                values=np.array([65.04, 126.1, 182.88, 235.67, 284.73, 330.32]) + 15.0,
                 unit='deg'),
             opening_angles_close=sc.array(
                 dims=[dim],
                 values=np.array([76.03, 141.4, 202.18, 254.97, 307.74, 360.0]) + 15.0,
-                unit='deg')),
+                unit='deg'),
+            kind=ChopperKind.WFM),
         "FOC1":
         Chopper(
             frequency=sc.scalar(56.0, unit=hz),
             phase=sc.scalar(62.40, unit='deg'),
-            position=sc.vector(value=[0, 0, 8.8], unit='m'),
+            position=sc.vector(value=[0, 0, 8.8 - 18.45], unit='m'),
             opening_angles_open=sc.array(
                 dims=[dim],
                 values=np.array([64.35, 125.05, 183.41, 236.4, 287.04, 335.53]) + 15.0,
@@ -58,12 +60,13 @@ def make_beamline() -> Beamline:
             opening_angles_close=sc.array(
                 dims=[dim],
                 values=np.array([84.99, 148.29, 205.22, 254.27, 302.8, 360.0]) + 15.0,
-                unit='deg')),
+                unit='deg'),
+            kind=ChopperKind.FRAME_OVERLAP),
         "FOC2":
         Chopper(
             frequency=sc.scalar(28.0, unit=hz),
             phase=sc.scalar(12.27, unit='deg'),
-            position=sc.vector(value=[0, 0, 15.9], unit='m'),
+            position=sc.vector(value=[0, 0, 15.9 - 18.45], unit='m'),
             opening_angles_open=sc.array(
                 dims=[dim],
                 values=np.array([79.78, 136.41, 191.73, 240.81, 287.13, 330.89]) + 15.0,
@@ -71,13 +74,13 @@ def make_beamline() -> Beamline:
             opening_angles_close=sc.array(
                 dims=[dim],
                 values=np.array([116.38, 172.47, 221.94, 267.69, 311.69, 360.0]) + 15.0,
-                unit='deg'))
+                unit='deg'),
+            kind=ChopperKind.FRAME_OVERLAP)
     }
 
     source = {
-        "pulse_length": sc.scalar(2.86e+03, unit='us'),
-        "pulse_t_0": sc.scalar(140.0, unit='us'),
-        "position": sc.vector(value=[0.0, 0.0, 0.0], unit='m')
+        "source_pulse_length": sc.scalar(2.86e+03, unit='us'),
+        "source_pulse_t_0": sc.scalar(140.0, unit='us'),
     }
 
-    return Beamline(choppers=choppers, source=source)
+    return {"choppers": choppers, "source": source}

--- a/src/ess/v20/imaging/beamline.py
+++ b/src/ess/v20/imaging/beamline.py
@@ -19,12 +19,18 @@ def make_beamline() -> dict:
     dim = 'frame'
     hz = sc.units.one / sc.units.s
 
+    source = {
+        "source_pulse_length": sc.scalar(2.86e+03, unit='us'),
+        "source_pulse_t_0": sc.scalar(140.0, unit='us'),
+        "source_position": sc.vector(value=[0.0, 0.0, -25.3], unit='m')
+    }
+
     choppers = {
         "WFMC1":
         Chopper(
             frequency=sc.scalar(70.0, unit=hz),
             phase=sc.scalar(47.10, unit='deg'),
-            position=sc.vector(value=[0, 0, 6.6 - 18.45], unit='m'),
+            position=source["source_position"] + sc.vector(value=[0, 0, 6.6], unit='m'),
             opening_angles_open=sc.array(
                 dims=[dim],
                 values=np.array([83.71, 140.49, 193.26, 242.32, 287.91, 330.3]) + 15.0,
@@ -38,7 +44,7 @@ def make_beamline() -> dict:
         Chopper(
             frequency=sc.scalar(70.0, unit=hz),
             phase=sc.scalar(76.76, unit='deg'),
-            position=sc.vector(value=[0, 0, 7.1 - 18.45], unit='m'),
+            position=source["source_position"] + sc.vector(value=[0, 0, 7.1], unit='m'),
             opening_angles_open=sc.array(
                 dims=[dim],
                 values=np.array([65.04, 126.1, 182.88, 235.67, 284.73, 330.32]) + 15.0,
@@ -52,7 +58,7 @@ def make_beamline() -> dict:
         Chopper(
             frequency=sc.scalar(56.0, unit=hz),
             phase=sc.scalar(62.40, unit='deg'),
-            position=sc.vector(value=[0, 0, 8.8 - 18.45], unit='m'),
+            position=source["source_position"] + sc.vector(value=[0, 0, 8.8], unit='m'),
             opening_angles_open=sc.array(
                 dims=[dim],
                 values=np.array([64.35, 125.05, 183.41, 236.4, 287.04, 335.53]) + 15.0,
@@ -66,7 +72,8 @@ def make_beamline() -> dict:
         Chopper(
             frequency=sc.scalar(28.0, unit=hz),
             phase=sc.scalar(12.27, unit='deg'),
-            position=sc.vector(value=[0, 0, 15.9 - 18.45], unit='m'),
+            position=source["source_position"] +
+            sc.vector(value=[0, 0, 15.9], unit='m'),
             opening_angles_open=sc.array(
                 dims=[dim],
                 values=np.array([79.78, 136.41, 191.73, 240.81, 287.13, 330.89]) + 15.0,
@@ -76,11 +83,6 @@ def make_beamline() -> dict:
                 values=np.array([116.38, 172.47, 221.94, 267.69, 311.69, 360.0]) + 15.0,
                 unit='deg'),
             kind=ChopperKind.FRAME_OVERLAP)
-    }
-
-    source = {
-        "source_pulse_length": sc.scalar(2.86e+03, unit='us'),
-        "source_pulse_t_0": sc.scalar(140.0, unit='us'),
     }
 
     return {"choppers": choppers, "source": source}


### PR DESCRIPTION
In the WFM time-distance diagram, the source position is assumed to be at zero.
So we need to take the difference between chopper position and source position everywhere.