### PR TITLE
Small fixes for ess-notebooks

### DIFF
--- a/src/ess/amor/amor_data.py
+++ b/src/ess/amor/amor_data.py
@@ -74,6 +74,11 @@ class AmorData(ReflData):
             detector_spatial_resolution=detector_spatial_resolution,
             data_file=data_file,
         )
+        # Convert tof nanoseconds to microseconds for convenience
+        self.data.bins.coords['tof'] = sc.to_unit(
+            self.data.bins.coords['tof'].astype('float64'), 'us')
+        self.data.coords['tof'] = sc.to_unit(self.data.coords['tof'].astype('float64'),
+                                             'us')
         # These are Amor specific parameters
         self.tau = 1 / (2 * chopper_speed)
         self.chopper_detector_distance = chopper_detector_distance
@@ -157,24 +162,22 @@ class AmorData(ReflData):
     def tof_correction(self):
         """
         A correction for the presense of the chopper with respect to the "true" ToF.
+        Also fold the two pulses.
+        TODO: generalise mechanism to fold any number of pulses.
         """
-        self.data.coords["position"].unit = sc.units.m
-        buf = self.data.bins.constituents["data"]
-        tof = sc.to_unit(buf.coords["tof"].astype(sc.dtype.float64), 'us')
-        tof.unit = sc.units.us
-        del buf.coords["tof"]
-        buf.coords["tof"] = tof
+        # Make 2 bins, one for each pulse
+        edges = sc.array(dims=['tof'],
+                         values=[0., self.tau.value, 2 * self.tau.value],
+                         unit=self.tau.unit)
+        self.data = sc.bin(self.data, edges=[edges])
+        # Make one offset for each bin
         tof_offset = self.tau * self.chopper_phase / (180.0 * sc.units.deg)
-        tof_cut = self.wavelength_cut * self.chopper_detector_distance / HDM
-        tof_e = (sc.Variable(
-            values=np.remainder((tof - tof_cut + self.tau).values, self.tau.values),
-            unit=sc.units.us,
-            dims=["event"],
-        ) + tof_cut + tof_offset)
-        buf = self.data.bins.constituents["data"]
-        tof = tof_e.astype(sc.dtype.float64)
-        del buf.coords["tof"]
-        buf.coords["tof"] = tof
+        offset = sc.concatenate(tof_offset, tof_offset - self.tau, 'tof')
+        # Apply the offset on both bins
+        self.data.bins.coords['tof'] += offset
+        # Rebin to exclude second (empty) pulse range
+        self.data = sc.bin(self.data,
+                           edges=[sc.concatenate(0. * sc.units.us, self.tau, 'tof')])
 
     def wavelength_masking(self, wavelength_min=None, wavelength_max=None):
         """

--- a/src/ess/amor/amor_data.py
+++ b/src/ess/amor/amor_data.py
@@ -60,7 +60,7 @@ class AmorData(ReflData):
         detector_spatial_resolution=0.0025 * sc.units.m,
         chopper_sample_distance=15.0 * sc.units.m,
         chopper_speed=20 / 3 * 1e-6 / sc.units.us,
-        chopper_detector_distance=1.9e11 * sc.units.angstrom,
+        chopper_detector_distance=19.0 * sc.units.m,
         chopper_chopper_distance=0.49 * sc.units.m,
         chopper_phase=-8.0 * sc.units.deg,
         wavelength_cut=2.4 * sc.units.angstrom,
@@ -75,10 +75,14 @@ class AmorData(ReflData):
             data_file=data_file,
         )
         # Convert tof nanoseconds to microseconds for convenience
-        self.data.bins.coords['tof'] = sc.to_unit(
-            self.data.bins.coords['tof'].astype('float64'), 'us')
-        self.data.coords['tof'] = sc.to_unit(self.data.coords['tof'].astype('float64'),
-                                             'us')
+        # TODO: is it safe to assume that the dtype of the binned wrapper coordinate is
+        # the same as the dtype of the underlying event coordinate?
+        if self.data.coords['tof'].dtype != sc.dtype.float64:
+            self.data.bins.coords['tof'] = self.data.bins.coords['tof'].astype(
+                'float64')
+            self.data.coords['tof'] = self.data.coords['tof'].astype('float64')
+        self.data.bins.coords['tof'] = sc.to_unit(self.data.bins.coords['tof'], 'us')
+        self.data.coords['tof'] = sc.to_unit(self.data.coords['tof'], 'us')
         # These are Amor specific parameters
         self.tau = 1 / (2 * chopper_speed)
         self.chopper_detector_distance = chopper_detector_distance
@@ -87,7 +91,7 @@ class AmorData(ReflData):
         self.wavelength_cut = wavelength_cut
         # The source position is not the true source position due to the
         # use of choppers to define the pulse.
-        self.data.attrs["source_position"] = sc.geometry.position(
+        self.data.coords["source_position"] = sc.geometry.position(
             0.0 * sc.units.m, 0.0 * sc.units.m, -chopper_sample_distance)
         self.tof_correction()
         # The wavelength contribution to the resolution function, defined
@@ -95,9 +99,9 @@ class AmorData(ReflData):
         # Division by 2np.sqrt(2*np.log(2)) converts from FWHM to std.
         self.data.coords["sigma_lambda_by_lambda"] = self.chopper_chopper_distance / (
             self.data.coords["position"].fields.z -
-            self.data.attrs["source_position"].fields.z)
+            self.data.coords["source_position"].fields.z)
         self.data.coords["sigma_lambda_by_lambda"] /= 2 * np.sqrt(2 * np.log(2))
-        self.find_wavelength()
+        self.find_wavelength(wavelength_cut=self.wavelength_cut)
         self.find_theta()
         self.illumination()
         self.find_qz()
@@ -190,8 +194,8 @@ class AmorData(ReflData):
         if wavelength_min is None:
             wavelength_min = self.wavelength_cut
         if wavelength_max is None:
-            wavelength_max = wavelength_min + self.tau * (
-                HDM / self.chopper_detector_distance)
+            wavelength_max = wavelength_min + sc.to_unit(
+                self.tau * (HDM / self.chopper_detector_distance), 'angstrom')
             if (wavelength_max > sc.max(self.event.coords["wavelength"])).value:
                 wavelength_max = sc.max(self.event.coords["wavelength"])
         wavelength_max = sc.to_unit(wavelength_max,

--- a/src/ess/reflectometry/binning.py
+++ b/src/ess/reflectometry/binning.py
@@ -25,20 +25,17 @@ def q_bin(data, bins):
     :rtype: scipp._scipp.core.DataArray
     :raises: NotFoundError is qz or tof coordinate cannot be found
     """
-    if 'qz' in data.events.coords:
-        erase = data.dims
-        data.events.coords['qz'] = sc.to_unit(data.events.coords['qz'], bins.unit)
-        binned = sc.bin(data, erase=erase, edges=[bins])
-        if 'sigma_qz_by_qz' in data.events.coords:
-            qzr = np.array([])
-            for i in binned.data.values:
-                try:
-                    qzr = np.append(qzr, i.coords['sigma_qz_by_qz'].values.max())
-                except ValueError:
-                    qzr = np.append(qzr, 0)
-            binned.coords['sigma_qz_by_qz'] = sc.Variable(values=qzr, dims=['qz'])
-    else:
-        raise sc.NotFoundError('qz coordinate cannot be found.')
+    erase = data.dims
+    data.events.coords['qz'] = sc.to_unit(data.events.coords['qz'], bins.unit)
+    binned = sc.bin(data, erase=erase, edges=[bins])
+    if 'sigma_qz_by_qz' in data.events.coords:
+        qzr = np.array([])
+        for i in binned.data.values:
+            try:
+                qzr = np.append(qzr, i.coords['sigma_qz_by_qz'].values.max())
+            except ValueError:
+                qzr = np.append(qzr, 0)
+        binned.coords['sigma_qz_by_qz'] = sc.Variable(values=qzr, dims=['qz'])
     return binned / (data.events.shape[0] * sc.units.dimensionless)
 
 

--- a/src/ess/reflectometry/binning.py
+++ b/src/ess/reflectometry/binning.py
@@ -18,15 +18,15 @@ def q_bin(data, bins):
 
     :param data: reflectometry data to be binned
     :type data: Union[ess.reflectometry.ReflData.data, ess.amor.AmorData.data, ess.amor.AmorReference.data]
-    :param bins: q-bin edges 
-    :type bins: scipp._scipp.core.Variable 
+    :param bins: q-bin edges
+    :type bins: scipp._scipp.core.Variable
 
     :return: Data array binned into qz with resolution
-    :rtype: scipp._scipp.core.DataArray 
-    :raises: NotFoundError is qz or tof coordinate cannot be found 
+    :rtype: scipp._scipp.core.DataArray
+    :raises: NotFoundError is qz or tof coordinate cannot be found
     """
-    if 'qz' in data.events.coords and 'tof' in data.events.coords:
-        erase = ['tof'] + data.dims
+    if 'qz' in data.events.coords:
+        erase = data.dims
         data.events.coords['qz'] = sc.to_unit(data.events.coords['qz'], bins.unit)
         binned = sc.bin(data, erase=erase, edges=[bins])
         if 'sigma_qz_by_qz' in data.events.coords:
@@ -38,7 +38,7 @@ def q_bin(data, bins):
                     qzr = np.append(qzr, 0)
             binned.coords['sigma_qz_by_qz'] = sc.Variable(values=qzr, dims=['qz'])
     else:
-        raise sc.NotFoundError('qz or tof coordinate cannot be found.')
+        raise sc.NotFoundError('qz coordinate cannot be found.')
     return binned / (data.events.shape[0] * sc.units.dimensionless)
 
 
@@ -50,9 +50,9 @@ def two_dimensional_bin(data, bins):
     :type data: Union[ess.reflectometry.ReflData.data, ess.amor.AmorData.data, ess.amor.AmorReference.data]
     :param bins: Bin edges
     :type bins: Tuple[scipp._scipp.core.Variable]
-    
+
     :return: Data array binned into given bin edges
-    :rtype: scipp._scipp.core.DataArray 
+    :rtype: scipp._scipp.core.DataArray
     """
     for i in bins:
         data.events.coords[i.dims[0]] = sc.to_unit(data.events.coords[i.dims[0]],

--- a/src/ess/reflectometry/data.py
+++ b/src/ess/reflectometry/data.py
@@ -87,7 +87,7 @@ class ReflData:
 
         :param bins: wavelength and theta edges
         :type bins: Tuple(scipp._scipp.core.Variable)
-        
+
         :return: Data array binned into wavelength and theta
         :rtype: scipp._scipp.core.DataArray
         """
@@ -124,10 +124,14 @@ class ReflData:
         """
         From the time-of-flight data, find the wavelength for each neutron event.
         """
-        scn.convert(self.data, origin="tof", target="wavelength", scatter=True)
-        self.data.bins.constituents["data"].coords["wavelength"] = (scn.convert(
-            self.data, origin="tof", target="wavelength",
-            scatter=True).bins.constituents["data"].coords["wavelength"])
+        # scn.convert(self.data, origin="tof", target="wavelength", scatter=True)
+        # self.data.bins.constituents["data"].coords["wavelength"] = (scn.convert(
+        #     self.data, origin="tof", target="wavelength",
+        #     scatter=True).bins.constituents["data"].coords["wavelength"])
+        self.data = scn.convert(self.data,
+                                origin='tof',
+                                target='wavelength',
+                                scatter=True)
 
     def find_theta(self):
         """
@@ -136,8 +140,8 @@ class ReflData:
         if self.gravity:
             nu_angle = corrections.angle_with_gravity(
                 self.data,
-                self.data.coords["position"],
-                self.data.attrs["sample_position"],
+                self.data.meta["position"],
+                self.data.meta["sample_position"],
             )
             theta = -self.sample_angle_offset + nu_angle
             self.data.bins.constituents["data"].coords["theta"] = theta
@@ -149,9 +153,9 @@ class ReflData:
             # Find the range of possible positions that the neutron could
             # strike, this range of theta values is taken to be the full
             # width half maximum for the theta distribution
-            offset_positive = resolution.z_offset(self.data.attrs["sample_position"],
+            offset_positive = resolution.z_offset(self.data.meta["sample_position"],
                                                   half_beam_on_sample)
-            offset_negative = resolution.z_offset(self.data.attrs["sample_position"],
+            offset_negative = resolution.z_offset(self.data.meta["sample_position"],
                                                   half_beam_on_sample)
             self.data.bins.constituents['data'].attrs[
                 'offset_positive'] = offset_positive
@@ -176,7 +180,7 @@ class ReflData:
             # sigma_gamma
             sigma_gamma = resolution.detector_resolution(
                 self.detector_spatial_resolution, self.data.coords["position"].fields.z,
-                self.data.attrs["sample_position"].fields.z)
+                self.data.meta["sample_position"].fields.z)
             self.data.attrs["sigma_gamma"] = sigma_gamma
             sigma_theta = sc.sqrt(
                 (self.data.attrs["sigma_gamma"] / self.data.bins.coords["theta"]) *

--- a/src/ess/reflectometry/data.py
+++ b/src/ess/reflectometry/data.py
@@ -124,10 +124,6 @@ class ReflData:
         """
         From the time-of-flight data, find the wavelength for each neutron event.
         """
-        # scn.convert(self.data, origin="tof", target="wavelength", scatter=True)
-        # self.data.bins.constituents["data"].coords["wavelength"] = (scn.convert(
-        #     self.data, origin="tof", target="wavelength",
-        #     scatter=True).bins.constituents["data"].coords["wavelength"])
         self.data = scn.convert(self.data,
                                 origin='tof',
                                 target='wavelength',

--- a/src/ess/reflectometry/data.py
+++ b/src/ess/reflectometry/data.py
@@ -120,7 +120,7 @@ class ReflData:
         return binning.two_dimensional_bin(
             self.data, bins) / (self.event.shape[0] * sc.units.dimensionless)
 
-    def find_wavelength(self):
+    def find_wavelength(self, wavelength_cut=None):
         """
         From the time-of-flight data, find the wavelength for each neutron event.
         """
@@ -128,6 +128,14 @@ class ReflData:
                                 origin='tof',
                                 target='wavelength',
                                 scatter=True)
+        # Select desired wavelength range
+        if wavelength_cut is not None:
+            self.data = sc.bin(self.data,
+                               edges=[
+                                   sc.concatenate(wavelength_cut,
+                                                  self.data.coords['wavelength'].max(),
+                                                  'wavelength')
+                               ])
 
     def find_theta(self):
         """

--- a/tests/amor/amor_data_test.py
+++ b/tests/amor/amor_data_test.py
@@ -17,7 +17,9 @@ from ..tools.io import file_location
 
 np.random.seed(1)
 
-N = 9
+# Make 20 neutrons in 2 pulses, so tof values extend up to 1.5e5 microseconds.
+# ArmorData folds the 2 pulses and performs a tof correction.
+N = 20
 VALUES = np.ones(N)
 DETECTORS = np.random.randint(1, 5, size=(N))
 
@@ -32,13 +34,20 @@ DATA = sc.DataArray(
         "detector_id": sc.Variable(dims=["event"],
                                    values=DETECTORS,
                                    dtype=sc.dtype.int32),
+        "tof": sc.linspace(dim="event",
+                           start=1.0e4,
+                           stop=1.4e5,
+                           num=N,
+                           unit=sc.units.us)
     },
 )
 
 DETECTOR_ID = sc.Variable(dims=["detector_id"],
                           values=np.arange(1, 5),
                           dtype=sc.dtype.int32)
-BINNED = sc.bin(DATA, groups=[DETECTOR_ID])
+BINNED = sc.bin(DATA,
+                edges=[sc.array(dims=["tof"], values=[0.5e4, 1.5e5], unit="us")],
+                groups=[DETECTOR_ID])
 
 PIXELS = np.array([[1, 1, 1], [1, 2, 1], [2, 1, 1], [2, 2, 1]])
 X = sc.Variable(
@@ -60,11 +69,6 @@ Z = sc.Variable(
     unit=sc.units.m,
 )
 BINNED.coords["position"] = sc.geometry.position(X, Y, Z)
-BINNED.events.coords["tof"] = sc.linspace(dim="event",
-                                          start=1,
-                                          stop=10,
-                                          num=N,
-                                          unit=sc.units.us)
 BINNED.attrs['sample_position'] = sc.geometry.position(0. * sc.units.m, 0. * sc.units.m,
                                                        0. * sc.units.m)
 BINNED.attrs['instrument_name'] = sc.scalar(value='AMOR')
@@ -77,115 +81,110 @@ class TestAmorData(unittest.TestCase):
         Testing the default initialisation of the AmorData objects.
         """
         p = amor_data.AmorData(BINNED.copy())
-        assert_equal(isinstance(p.data, sc._scipp.core.DataArray), True)
-        assert_equal(isinstance(p.data.data, sc._scipp.core.Variable), True)
-        assert_almost_equal(
-            np.sort(p.data.bins.constituents["data"].coords["tof"].values),
-            [
-                71667.6666667, 71668.7916667, 71669.9166667, 71671.0416667,
-                71672.1666667, 71673.2916667, 71674.4166667, 71675.5416667,
-                71676.6666667
-            ],
-        )
-        assert_almost_equal(
-            p.data.attrs['source_position'].values,
-            sc.geometry.position(0. * sc.units.m, 0. * sc.units.m,
-                                 -15. * sc.units.m).values)
-        assert_almost_equal(p.data.coords['sigma_lambda_by_lambda'].values,
-                            [0.0130052, 0.0130052, 0.0130052, 0.0130052])
-        assert_almost_equal(p.tau.value, 75000)
-        assert_almost_equal(p.chopper_detector_distance.value, 19e10)
-        assert_almost_equal(p.chopper_chopper_distance.value, 0.49)
-        assert_almost_equal(p.chopper_phase.value, -8)
-        assert_almost_equal(p.wavelength_cut.value, 2.4)
+        assert isinstance(p.data, sc._scipp.core.DataArray)
+        assert isinstance(p.data.data, sc._scipp.core.Variable)
+        # We cut off the wavelength at 2.4 angsrtoms, which discards 3 neutrons
+        assert len(p.data.bins.constituents["data"].coords["wavelength"].values) == 17
+        assert sc.allclose(
+            sc.sort(p.data.bins.constituents["data"].coords["wavelength"], 'event'),
+            sc.array(dims=['event'],
+                     values=[
+                         2.9689534, 3.2561593, 4.5305458, 4.8116494, 6.2246763,
+                         6.4293591, 7.4802203, 8.1092884, 9.2674094, 9.3270709,
+                         10.4877315, 10.8782681, 12.369804, 12.4294654, 13.4952427,
+                         14.5801273, 16.1356174
+                     ],
+                     unit='angstrom'))
+        assert sc.identical(
+            p.data.coords['source_position'],
+            sc.geometry.position(0. * sc.units.m, 0. * sc.units.m, -15. * sc.units.m))
+        assert sc.allclose(p.data.coords['sigma_lambda_by_lambda'],
+                           sc.array(dims=['detector_id'], values=[0.0130052] * 4))
+        assert sc.identical(p.tau, sc.scalar(7.5e4, unit='us'))
+        assert sc.identical(p.chopper_detector_distance, sc.scalar(19., unit='m'))
+        assert sc.identical(p.chopper_chopper_distance, sc.scalar(0.49, unit='m'))
+        assert sc.identical(p.chopper_phase, sc.scalar(-8.0, unit='deg'))
+        assert sc.identical(p.wavelength_cut, sc.scalar(2.4, unit='angstrom'))
 
     def test_amordata_init_nodefault(self):
         """
-        Testing the default initialisation of the AmorData objects.
+        Testing the initialisation of the AmorData objects without defaults.
         """
-        p = amor_data.AmorData(BINNED.copy(),
-                               reduction_creator='andrew',
-                               data_owner='andrew',
-                               reduction_creator_affiliation='ess',
-                               experiment_id='1234',
-                               experiment_date='2021-04-21',
-                               sample_description='my sample',
-                               reduction_file='my_notebook.ipynb',
-                               chopper_phase=-5 * sc.units.deg,
-                               chopper_chopper_distance=0.3 * sc.units.m,
-                               chopper_detector_distance=18e10 * sc.units.angstrom,
-                               wavelength_cut=2.0 * sc.units.angstrom)
-        assert_equal(isinstance(p.data, sc._scipp.core.DataArray), True)
-        assert_equal(isinstance(p.data.data, sc._scipp.core.Variable), True)
-        assert_almost_equal(
-            np.sort(p.data.bins.constituents["data"].coords["tof"].values),
-            [
-                72917.6666667, 72918.7916667, 72919.9166667, 72921.0416667,
-                72922.1666667, 72923.2916667, 72924.4166667, 72925.5416667,
-                72926.6666667
-            ],
-        )
-        assert_almost_equal(
-            p.data.attrs['source_position'].values,
-            sc.geometry.position(0. * sc.units.m, 0. * sc.units.m,
-                                 -15. * sc.units.m).values)
-        assert_almost_equal(p.data.coords['sigma_lambda_by_lambda'].values,
-                            [0.0079624, 0.0079624, 0.0079624, 0.0079624])
-        assert_almost_equal(p.tau.value, 75000)
-        assert_almost_equal(p.chopper_detector_distance.value, 18e10)
-        assert_almost_equal(p.chopper_chopper_distance.value, 0.3)
-        assert_almost_equal(p.chopper_phase.value, -5)
-        assert_almost_equal(p.wavelength_cut.value, 2.)
-        assert_equal(p.orso.creator.name, 'andrew')
-        assert_equal(p.orso.creator.affiliation, 'ess')
-        assert_equal(p.orso.data_source.owner, 'andrew')
-        assert_equal(p.orso.data_source.experiment_id, '1234')
-        assert_equal(p.orso.data_source.experiment_date, '2021-04-21')
-        assert_equal(p.orso.reduction.script, 'my_notebook.ipynb')
+        kwargs = {
+            'reduction_creator': 'andrew',
+            'data_owner': 'andrew',
+            'reduction_creator_affiliation': 'ess',
+            'experiment_id': '1234',
+            'experiment_date': '2021-04-21',
+            'sample_description': 'my sample',
+            'reduction_file': 'my_notebook.ipynb',
+            'chopper_phase': -5 * sc.units.deg,
+            'chopper_chopper_distance': 0.3 * sc.units.m,
+            'chopper_detector_distance': 18. * sc.units.m,
+            'wavelength_cut': 1.4 * sc.units.angstrom
+        }
+
+        p = amor_data.AmorData(BINNED.copy(), **kwargs)
+        # We cut off the wavelength at 1.4 angsrtoms, which discards 1 neutron
+        assert len(p.data.bins.constituents["data"].coords["wavelength"].values) == 19
+        assert sc.allclose(
+            sc.sort(p.data.bins.constituents["data"].coords["wavelength"], 'event'),
+            sc.array(dims=['event'],
+                     values=[
+                         1.79481481, 1.85447624, 3.24367799, 3.55170242, 4.80527036,
+                         5.10719253, 6.5080681, 6.72490224, 7.75494484, 8.40483156,
+                         9.55080124, 9.61046267, 10.76245608, 11.16165996, 12.65319581,
+                         12.71285725, 13.76996732, 14.87567042, 16.43116053
+                     ],
+                     unit='angstrom'))
+        assert sc.identical(
+            p.data.coords['source_position'],
+            sc.geometry.position(0. * sc.units.m, 0. * sc.units.m, -15. * sc.units.m))
+        assert sc.allclose(p.data.coords['sigma_lambda_by_lambda'],
+                           sc.array(dims=['detector_id'], values=[0.0079624] * 4))
+        assert sc.identical(p.tau, sc.scalar(7.5e4, unit='us'))
+        assert sc.identical(p.chopper_detector_distance,
+                            kwargs['chopper_detector_distance'])
+        assert sc.identical(p.chopper_chopper_distance,
+                            kwargs['chopper_chopper_distance'])
+        assert sc.identical(p.chopper_phase, kwargs['chopper_phase'])
+        assert sc.identical(p.wavelength_cut, kwargs['wavelength_cut'])
+
+        assert p.orso.creator.name == 'andrew'
+        assert p.orso.creator.affiliation == 'ess'
+        assert p.orso.data_source.owner == 'andrew'
+        assert p.orso.data_source.experiment_id == '1234'
+        assert p.orso.data_source.experiment_date == '2021-04-21'
+        assert p.orso.reduction.script == 'my_notebook.ipynb'
 
     def test_wavelength_masking(self):
         p = amor_data.AmorData(BINNED.copy())
-        p.event.coords["wavelength"] = sc.Variable(
-            dims=["event"],
-            values=DETECTORS,
-            dtype=sc.dtype.float64,
-            unit=sc.units.angstrom,
-        )
         p.wavelength_masking(
             wavelength_min=2 * sc.units.angstrom,
             wavelength_max=4 * sc.units.angstrom,
         )
         assert_equal(
             p.event.masks["wavelength"].values,
-            ~((DETECTORS >= 2) & (DETECTORS <= 4)),
+            ~((p.event.coords["wavelength"].values >= 2) &
+              (p.event.coords["wavelength"].values <= 4)),
         )
 
     def test_wavelength_masking_no_min(self):
         p = amor_data.AmorData(BINNED.copy())
-        p.event.coords["wavelength"] = sc.Variable(
-            dims=["event"],
-            values=DETECTORS,
-            dtype=sc.dtype.float64,
-            unit=sc.units.angstrom,
-        )
         p.wavelength_masking(wavelength_max=4 * sc.units.angstrom)
         assert_equal(
             p.event.masks["wavelength"].values,
-            ~((DETECTORS >= 2.4) & (DETECTORS <= 4)),
+            ~((p.event.coords["wavelength"].values >= 2.4) &
+              (p.event.coords["wavelength"].values <= 4)),
         )
 
     def test_wavelength_masking_no_max(self):
         p = amor_data.AmorData(BINNED.copy())
-        p.event.coords["wavelength"] = sc.Variable(
-            dims=["event"],
-            values=DETECTORS,
-            dtype=sc.dtype.float64,
-            unit=sc.units.angstrom,
-        )
         p.wavelength_masking(wavelength_min=2 * sc.units.angstrom)
         assert_equal(
             p.event.masks["wavelength"].values,
-            ~((DETECTORS >= 2) & (DETECTORS <= 5)),
+            ~((p.event.coords["wavelength"].values >= 2) &
+              (p.event.coords["wavelength"].values <= 16.2)),
         )
 
 
@@ -198,7 +197,7 @@ class TestAmorReference(unittest.TestCase):
         assert_equal(isinstance(p.data, sc._scipp.core.DataArray), True)
         assert_equal(isinstance(p.data.data, sc._scipp.core.Variable), True)
         assert_equal(p.m_value.value, 5)
-        assert_almost_equal(p.event.coords['normalisation'].values, np.ones(9))
+        assert_almost_equal(p.event.coords['normalisation'].values, np.ones(17))
 
     def test_amorreference_init_nodefault(self):
         """
@@ -208,7 +207,7 @@ class TestAmorReference(unittest.TestCase):
         assert_equal(isinstance(p.data, sc._scipp.core.DataArray), True)
         assert_equal(isinstance(p.data.data, sc._scipp.core.Variable), True)
         assert_equal(p.m_value.value, 4)
-        assert_almost_equal(p.event.coords['normalisation'].values, np.ones(9))
+        assert_almost_equal(p.event.coords['normalisation'].values, np.ones(17))
 
 
 class TestNormalisation(unittest.TestCase):
@@ -232,18 +231,21 @@ class TestNormalisation(unittest.TestCase):
 
     def test_q_bin_norm(self):
         p = amor_data.AmorData(BINNED.copy())
-        p.event.coords["wavelength"] = sc.Variable(dims=["event"],
-                                                   values=DETECTORS.astype(float),
-                                                   unit=sc.units.angstrom)
+        nevents = p.event.coords["wavelength"].sizes['event']
+        p.event.coords["wavelength"] = sc.Variable(
+            dims=["event"],
+            values=DETECTORS[:nevents].astype(float),
+            unit=sc.units.angstrom)
         p.event.coords["theta"] = sc.Variable(dims=["event"],
-                                              values=DETECTORS.astype(float),
+                                              values=DETECTORS[:nevents].astype(float),
                                               unit=sc.units.deg)
         q = amor_data.AmorData(BINNED.copy())
-        q.event.coords["wavelength"] = sc.Variable(dims=["event"],
-                                                   values=DETECTORS.astype(float),
-                                                   unit=sc.units.angstrom)
+        q.event.coords["wavelength"] = sc.Variable(
+            dims=["event"],
+            values=DETECTORS[:nevents].astype(float),
+            unit=sc.units.angstrom)
         q.event.coords["theta"] = sc.Variable(dims=["event"],
-                                              values=DETECTORS.astype(float),
+                                              values=DETECTORS[:nevents].astype(float),
                                               unit=sc.units.deg)
         z = amor_data.Normalisation(p, q)
         del z.sample.event.coords['qz']
@@ -252,18 +254,21 @@ class TestNormalisation(unittest.TestCase):
 
     def test_write_reflectometry_norm(self):
         p = amor_data.AmorData(BINNED.copy())
-        p.event.coords["wavelength"] = sc.Variable(dims=["event"],
-                                                   values=DETECTORS.astype(float),
-                                                   unit=sc.units.angstrom)
+        nevents = p.event.coords["wavelength"].sizes['event']
+        p.event.coords["wavelength"] = sc.Variable(
+            dims=["event"],
+            values=DETECTORS[:nevents].astype(float),
+            unit=sc.units.angstrom)
         p.event.coords["theta"] = sc.Variable(dims=["event"],
-                                              values=DETECTORS.astype(float),
+                                              values=DETECTORS[:nevents].astype(float),
                                               unit=sc.units.deg)
         q = amor_data.AmorData(BINNED.copy())
-        q.event.coords["wavelength"] = sc.Variable(dims=["event"],
-                                                   values=DETECTORS.astype(float),
-                                                   unit=sc.units.angstrom)
+        q.event.coords["wavelength"] = sc.Variable(
+            dims=["event"],
+            values=DETECTORS[:nevents].astype(float),
+            unit=sc.units.angstrom)
         q.event.coords["theta"] = sc.Variable(dims=["event"],
-                                              values=DETECTORS.astype(float),
+                                              values=DETECTORS[:nevents].astype(float),
                                               unit=sc.units.deg)
         z = amor_data.Normalisation(p, q)
         with file_location("test1.txt") as file_path:
@@ -273,18 +278,21 @@ class TestNormalisation(unittest.TestCase):
 
     def test_binwavelength_theta_norm(self):
         p = amor_data.AmorData(BINNED.copy())
-        p.event.coords["wavelength"] = sc.Variable(dims=["event"],
-                                                   values=DETECTORS.astype(float),
-                                                   unit=sc.units.angstrom)
+        nevents = p.event.coords["wavelength"].sizes['event']
+        p.event.coords["wavelength"] = sc.Variable(
+            dims=["event"],
+            values=DETECTORS[:nevents].astype(float),
+            unit=sc.units.angstrom)
         p.event.coords["theta"] = sc.Variable(dims=["event"],
-                                              values=DETECTORS.astype(float),
+                                              values=DETECTORS[:nevents].astype(float),
                                               unit=sc.units.deg)
         q = amor_data.AmorData(BINNED.copy())
-        q.event.coords["wavelength"] = sc.Variable(dims=["event"],
-                                                   values=DETECTORS.astype(float),
-                                                   unit=sc.units.angstrom)
+        q.event.coords["wavelength"] = sc.Variable(
+            dims=["event"],
+            values=DETECTORS[:nevents].astype(float),
+            unit=sc.units.angstrom)
         q.event.coords["theta"] = sc.Variable(dims=["event"],
-                                              values=DETECTORS.astype(float),
+                                              values=DETECTORS[:nevents].astype(float),
                                               unit=sc.units.deg)
         z = amor_data.Normalisation(p, q)
         bins1 = sc.linspace(dim='wavelength',
@@ -298,18 +306,21 @@ class TestNormalisation(unittest.TestCase):
 
     def test_write_wavelength_theta_norm(self):
         p = amor_data.AmorData(BINNED.copy())
-        p.event.coords["wavelength"] = sc.Variable(dims=["event"],
-                                                   values=DETECTORS.astype(float),
-                                                   unit=sc.units.angstrom)
+        nevents = p.event.coords["wavelength"].sizes['event']
+        p.event.coords["wavelength"] = sc.Variable(
+            dims=["event"],
+            values=DETECTORS[:nevents].astype(float),
+            unit=sc.units.angstrom)
         p.event.coords["theta"] = sc.Variable(dims=["event"],
-                                              values=DETECTORS.astype(float),
+                                              values=DETECTORS[:nevents].astype(float),
                                               unit=sc.units.deg)
         q = amor_data.AmorData(BINNED.copy())
-        q.event.coords["wavelength"] = sc.Variable(dims=["event"],
-                                                   values=DETECTORS.astype(float),
-                                                   unit=sc.units.angstrom)
+        q.event.coords["wavelength"] = sc.Variable(
+            dims=["event"],
+            values=DETECTORS[:nevents].astype(float),
+            unit=sc.units.angstrom)
         q.event.coords["theta"] = sc.Variable(dims=["event"],
-                                              values=DETECTORS.astype(float),
+                                              values=DETECTORS[:nevents].astype(float),
                                               unit=sc.units.deg)
         z = amor_data.Normalisation(p, q)
         with file_location("test1.txt") as file_path:

--- a/tests/reflectometry/data_test.py
+++ b/tests/reflectometry/data_test.py
@@ -200,27 +200,6 @@ class TestData(unittest.TestCase):
         assert_almost_equal(b.data.values, np.array([3.0, 3.0, 3.]) / 9.)
         assert_almost_equal(b.data.variances, np.array([3.0, 3.0, 3.]) / 81.)
 
-    def test_q_bin_no_tof(self):
-        p = data.ReflData(BINNED.copy())
-        p.event.coords["qz"] = sc.linspace(dim="event",
-                                           start=1,
-                                           stop=10,
-                                           num=N,
-                                           unit=sc.Unit('1/angstrom'))
-        p.event.coords["sigma_qz_by_qz"] = sc.linspace(dim="event",
-                                                       start=0.1,
-                                                       stop=1.0,
-                                                       num=N,
-                                                       unit=sc.Unit('1/angstrom'),
-                                                       dtype=sc.dtype.float64)
-        bins = sc.linspace(dim='qz',
-                           start=0.,
-                           stop=11.,
-                           num=4,
-                           unit=sc.Unit('1/angstrom'))
-        with self.assertRaises(sc.NotFoundError):
-            _ = p.q_bin(bins)
-
     def test_wavelength_theta_bin(self):
         p = data.ReflData(BINNED.copy())
         p.event.coords["wavelength"] = sc.Variable(


### PR DESCRIPTION
- Convert to microseconds at the start, to allow for less code in tof correction.
- Also use `data.meta` instead of `.attrs`