### PR TITLE
Modify tof range in Amor data time correction

### DIFF
--- a/src/ess/amor/amor_data.py
+++ b/src/ess/amor/amor_data.py
@@ -169,13 +169,16 @@ class AmorData(ReflData):
         Also fold the two pulses.
         TODO: generalise mechanism to fold any number of pulses.
         """
+        tof_offset = self.tau * self.chopper_phase / (180.0 * sc.units.deg)
         # Make 2 bins, one for each pulse
         edges = sc.array(dims=['tof'],
-                         values=[0., self.tau.value, 2 * self.tau.value],
+                         values=[
+                             -tof_offset.value, (self.tau - tof_offset).value,
+                             (2 * (self.tau - tof_offset)).value
+                         ],
                          unit=self.tau.unit)
         self.data = sc.bin(self.data, edges=[edges])
         # Make one offset for each bin
-        tof_offset = self.tau * self.chopper_phase / (180.0 * sc.units.deg)
         offset = sc.concatenate(tof_offset, tof_offset - self.tau, 'tof')
         # Apply the offset on both bins
         self.data.bins.coords['tof'] += offset

--- a/src/ess/amor/amor_data.py
+++ b/src/ess/amor/amor_data.py
@@ -174,7 +174,7 @@ class AmorData(ReflData):
         edges = sc.array(dims=['tof'],
                          values=[
                              -tof_offset.value, (self.tau - tof_offset).value,
-                             (2 * (self.tau - tof_offset)).value
+                             (2 * self.tau - tof_offset).value
                          ],
                          unit=self.tau.unit)
         self.data = sc.bin(self.data, edges=[edges])


### PR DESCRIPTION
Adjust for `tof_offset` when selecting tof range to avoid zero counts at high tof end.

Before:
![Screenshot at 2021-10-05 16-02-48](https://user-images.githubusercontent.com/39047984/136038619-59ddf000-5af7-4bbd-9534-b76a2a217eb8.png)

After:
![Screenshot at 2021-10-05 16-01-52](https://user-images.githubusercontent.com/39047984/136038648-44cacc33-426f-427b-84c5-b9449f815269.png)

This also caused issues with infinite values in the [amor reduction](https://scipp.github.io/ess-notebooks/reflectometry/amor_reduction.html) notebook