### PR TITLE
Update amor reduction notebook

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -13,7 +13,7 @@ requirements:
     - ipywidgets
     - matplotlib
     - pooch
-    - scippneutron=0.4.1
+    - scippneutron>=0.4.2
     - scipy
     - tifffile
 
@@ -43,7 +43,7 @@ build:
   number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}
   noarch: python
   script:
-    - python setup.py install
+    - pip install .
 
 about:
   home: https://github.com/scipp/ess

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -13,7 +13,7 @@ requirements:
     - ipywidgets
     - matplotlib
     - pooch
-    - scippneutron>=0.4.1
+    - scippneutron=0.4.1
     - scipy
     - tifffile
 

--- a/docs/instruments/amor/amor_reduction.ipynb
+++ b/docs/instruments/amor/amor_reduction.ipynb
@@ -290,7 +290,7 @@
     "q_edges = sc.geomspace(dim='Q', start=0.008, stop=0.08, num=201, unit='1/angstrom')\n",
     "sample_q_binned = sc.bin(sample_q, edges=[q_edges])\n",
     "sample_q_summed = sample_q_binned.sum('detector_id')\n",
-    "sc.plot(sample_q_summed[\"wavelength\", 0], norm=\"log\")"
+    "sc.plot(sample_q_summed, norm=\"log\")"
    ]
   },
   {
@@ -354,7 +354,7 @@
     "reference_q = reference_wav.transform_coords([\"Q\"], graph=graph)\n",
     "reference_q_binned = sc.bin(reference_q, edges=[q_edges])\n",
     "reference_q_summed = reference_q_binned.sum('detector_id')\n",
-    "sc.plot(reference_q_summed[\"wavelength\", 0], norm=\"log\")"
+    "sc.plot(reference_q_summed, norm=\"log\")"
    ]
   },
   {
@@ -372,7 +372,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "normalized = sample_q_summed[\"wavelength\", 0] / reference_q_summed[\"wavelength\", 0]\n",
+    "normalized = sample_q_summed / reference_q_summed\n",
     "sc.plot(normalized, norm=\"log\")"
    ]
   },


### PR DESCRIPTION
Wavelength slicing is no longer needed now that dimension renaming in `scippneutron` renames wavelength to Q.