### PR TITLE
Fix anaconda not found

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,8 +26,10 @@ jobs:
         with:
           fetch-depth: 0  # history required so cmake can determine version
       - uses: conda-incubator/setup-miniconda@v2
-      - run: conda install --channel conda-forge --yes conda-build mamba boa
-      - run: conda mambabuild --channel conda-forge --channel scipp --no-anaconda-upload --override-channels --output-folder conda/package conda
+      - shell: bash -l {0}
+        run: |
+          conda install --channel conda-forge --yes conda-build mamba boa
+          conda mambabuild --channel conda-forge --channel scipp --no-anaconda-upload --override-channels --output-folder conda/package conda
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,10 @@ name: Build
 on:
   workflow_call:
 
+defaults:
+  run:
+    shell: bash -l {0}  # required for conda env
+
 jobs:
   formatting:
     runs-on: ubuntu-latest
@@ -26,10 +30,8 @@ jobs:
         with:
           fetch-depth: 0  # history required so cmake can determine version
       - uses: conda-incubator/setup-miniconda@v2
-      - shell: bash -l {0}
-        run: |
-          conda install --channel conda-forge --yes conda-build mamba boa
-          conda mambabuild --channel conda-forge --channel scipp --no-anaconda-upload --override-channels --output-folder conda/package conda
+      - run: conda install --channel conda-forge --yes conda-build mamba boa
+      - run: conda mambabuild --channel conda-forge --channel scipp --no-anaconda-upload --override-channels --output-folder conda/package conda
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,8 +12,10 @@ jobs:
       - uses: actions/checkout@v2  # Need to checkout repo so github-pages-deploy-action works
       - uses: actions/download-artifact@v2
       - uses: conda-incubator/setup-miniconda@v2
-      - run: conda install -c conda-forge --yes anaconda-client
-      - run: anaconda --token ${{ secrets.ANACONDATOKEN }} upload --user scipp --label ${{ env.conda_label }} $(ls conda-package-*/*/*.tar.bz2)
+      - shell: bash -l {0}
+        run: |
+          conda install -c conda-forge --yes anaconda-client
+          anaconda --token ${{ secrets.ANACONDATOKEN }} upload --user scipp --label ${{ env.conda_label }} $(ls conda-package-*/*/*.tar.bz2)
 
       - uses: JamesIves/github-pages-deploy-action@v4.2.2
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,6 +2,9 @@ name: Deploy
 
 on:
   workflow_call:
+    secrets:
+      anaconda_token:
+        required: true
 
 defaults:
   run:
@@ -17,7 +20,7 @@ jobs:
       - run: conda install -c conda-forge --yes anaconda-client
       - uses: actions/checkout@v2  # Need to checkout repo so github-pages-deploy-action works
       - uses: actions/download-artifact@v2
-      - run: anaconda --token ${{ secrets.ANACONDATOKEN }} upload --user scipp --label ${{ env.conda_label }} $(ls conda-package-*/*/*.tar.bz2)
+      - run: anaconda --token ${{ secrets.anaconda_token }} upload --user scipp --label ${{ env.conda_label }} $(ls conda-package-*/*/*.tar.bz2)
 
       - uses: JamesIves/github-pages-deploy-action@v4.2.2
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,19 +3,21 @@ name: Deploy
 on:
   workflow_call:
 
+defaults:
+  run:
+    shell: bash -l {0}  # required for conda env
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
     env:
       conda_label: ${{ startsWith(github.ref, 'refs/tags/') && 'main' || 'dev' }}
     steps:
+      - uses: conda-incubator/setup-miniconda@v2
+      - run: conda install -c conda-forge --yes anaconda-client
       - uses: actions/checkout@v2  # Need to checkout repo so github-pages-deploy-action works
       - uses: actions/download-artifact@v2
-      - uses: conda-incubator/setup-miniconda@v2
-      - shell: bash -l {0}
-        run: |
-          conda install -c conda-forge --yes anaconda-client
-          anaconda --token ${{ secrets.ANACONDATOKEN }} upload --user scipp --label ${{ env.conda_label }} $(ls conda-package-*/*/*.tar.bz2)
+      - run: anaconda --token ${{ secrets.ANACONDATOKEN }} upload --user scipp --label ${{ env.conda_label }} $(ls conda-package-*/*/*.tar.bz2)
 
       - uses: JamesIves/github-pages-deploy-action@v4.2.2
         with:

--- a/.github/workflows/pr_and_main.yml
+++ b/.github/workflows/pr_and_main.yml
@@ -12,4 +12,4 @@ concurrency:
 
 jobs:
   build:
-    uses: scipp/ess/.github/workflows/build.yml@anaconda_not_found
+    uses: scipp/ess/.github/workflows/build.yml@main

--- a/.github/workflows/pr_and_main.yml
+++ b/.github/workflows/pr_and_main.yml
@@ -12,4 +12,4 @@ concurrency:
 
 jobs:
   build:
-    uses: scipp/ess/.github/workflows/build.yml@main
+    uses: scipp/ess/.github/workflows/build.yml@anaconda_not_found

--- a/.github/workflows/weekly_and_release.yml
+++ b/.github/workflows/weekly_and_release.yml
@@ -14,5 +14,5 @@ jobs:
   deploy:
     needs: build
     uses: scipp/ess/.github/workflows/deploy.yml@anaconda_not_found
-      secrets:
-        anaconda_token: ${{ secrets.ANACONDATOKEN }}
+    secrets:
+      anaconda_token: ${{ secrets.ANACONDATOKEN }}

--- a/.github/workflows/weekly_and_release.yml
+++ b/.github/workflows/weekly_and_release.yml
@@ -14,3 +14,5 @@ jobs:
   deploy:
     needs: build
     uses: scipp/ess/.github/workflows/deploy.yml@anaconda_not_found
+      secrets:
+        anaconda_token: ${{ secrets.ANACONDATOKEN }}

--- a/.github/workflows/weekly_and_release.yml
+++ b/.github/workflows/weekly_and_release.yml
@@ -7,6 +7,10 @@ on:
     - cron: "0 2 * * 4"
   workflow_dispatch:
 
+defaults:
+  run:
+    shell: bash -l {0}  # required for conda env
+
 jobs:
   build:
     uses: scipp/ess/.github/workflows/build.yml@main

--- a/.github/workflows/weekly_and_release.yml
+++ b/.github/workflows/weekly_and_release.yml
@@ -7,14 +7,10 @@ on:
     - cron: "0 2 * * 4"
   workflow_dispatch:
 
-defaults:
-  run:
-    shell: bash -l {0}  # required for conda env
-
 jobs:
   build:
-    uses: scipp/ess/.github/workflows/build.yml@main
+    uses: scipp/ess/.github/workflows/build.yml@anaconda_not_found
 
   deploy:
     needs: build
-    uses: scipp/ess/.github/workflows/deploy.yml@main
+    uses: scipp/ess/.github/workflows/deploy.yml@anaconda_not_found

--- a/.github/workflows/weekly_and_release.yml
+++ b/.github/workflows/weekly_and_release.yml
@@ -9,10 +9,10 @@ on:
 
 jobs:
   build:
-    uses: scipp/ess/.github/workflows/build.yml@anaconda_not_found
+    uses: scipp/ess/.github/workflows/build.yml@main
 
   deploy:
     needs: build
-    uses: scipp/ess/.github/workflows/deploy.yml@anaconda_not_found
+    uses: scipp/ess/.github/workflows/deploy.yml@main
     secrets:
       anaconda_token: ${{ secrets.ANACONDATOKEN }}


### PR DESCRIPTION
- Use `shell: bash -l {0}` so that `anaconda` command is found
- Pass secret anaconda token from top level workflow to reuseable workflow