### PR TITLE
Add more files / folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,6 @@ src/ess/_version.py
 
 # Caches
 .ipynb_checkpoints
+.mypy_cache
 .virtual_documents
 __pycache__

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 # Build artifacts
 build
 *.pyc
-_fixed_version.py
 docs/generated
 ess.egg-info
 src/ess/_version.py

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,17 @@
+# Build artifacts
+build
 *.pyc
-.idea
 _fixed_version.py
+docs/generated
+ess.egg-info
+src/ess/_version.py
+
+# IDE / Editor settings
+.idea
+.vscode
+.vs
+
+# Caches
+.ipynb_checkpoints
+.virtual_documents
+__pycache__


### PR DESCRIPTION
Some of these were taken from scipp, others from my local installation.
- I used `build` for the docs. I'm open to pick a different directory if we want to have a standard location.
- The egg comes from installing `ess` in developer mode (`pip install -e .`)