### PR TITLE
First pass for logging

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -49,6 +49,15 @@ extensions = [
 
 autodoc_typehints = 'description'
 
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3', None),
+    'numpy': ('https://docs.scipy.org/doc/numpy/', None),
+    'scipp': ('https://scipp.github.io/', None),
+    'scippneutron': ('https://scipp.github.io/scippneutron', None),
+    'scipy': ('https://docs.scipy.org/doc/scipy/', None),
+    'xarray': ('https://xarray.pydata.org/en/stable/', None)
+}
+
 # autodocs includes everything, even irrelevant API internals. autosummary
 # looks more suitable in the long run when the API grows.
 # For a nice example see how xarray handles its API documentation.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -44,6 +44,12 @@ Documentation
    techniques/wfm/wfm
 
 .. toctree::
+   :maxdepth: 2
+   :caption: Utilities
+
+   utilities/utilities
+
+.. toctree::
    :caption: About
    :maxdepth: 3
 

--- a/docs/instruments/amor/amor_reduction.ipynb
+++ b/docs/instruments/amor/amor_reduction.ipynb
@@ -42,9 +42,7 @@
   {
    "cell_type": "markdown",
    "id": "dde6c61a-39ed-4e85-af6e-0915baf3ad1b",
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "## The Amor beamline\n",
     "\n",

--- a/docs/instruments/amor/amor_reduction.ipynb
+++ b/docs/instruments/amor/amor_reduction.ipynb
@@ -19,18 +19,34 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c55f69ba-80db-4cf7-9b32-3865f952a13d",
+   "id": "455b7a61-5a5d-4d94-993c-02fe41c84e50",
    "metadata": {},
    "outputs": [],
    "source": [
+    "import logging\n",
     "import scipp as sc\n",
-    "from ess import amor"
+    "from ess import amor\n",
+    "import ess"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1c89f088-0663-49ce-a999-8be271f2e24a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ess.logging.configure(level=logging.DEBUG, root='overwrite')\n",
+    "ess.logging.greet()\n",
+    "sc.display_logs()"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "dde6c61a-39ed-4e85-af6e-0915baf3ad1b",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## The Amor beamline\n",
     "\n",
@@ -476,7 +492,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.5"
+   "version": "3.9.9"
   }
  },
  "nbformat": 4,

--- a/docs/instruments/amor/amor_reduction.ipynb
+++ b/docs/instruments/amor/amor_reduction.ipynb
@@ -99,7 +99,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "logger.info('Loading primary data file')\n",
     "sample = amor.load(amor.data.get_path(\"sample.nxs\"),\n",
     "                   beamline=amor_beamline)\n",
     "sample"

--- a/docs/instruments/amor/amor_reduction.ipynb
+++ b/docs/instruments/amor/amor_reduction.ipynb
@@ -323,7 +323,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "logger.info('Loading reference file for normalization')\n",
     "reference = amor.load(amor.data.get_path(\"reference.nxs\"),\n",
     "                      beamline=amor_beamline)\n",
     "reference.coords['position'].fields.y += pixel_position_correction(reference)\n",

--- a/docs/instruments/amor/amor_reduction.ipynb
+++ b/docs/instruments/amor/amor_reduction.ipynb
@@ -36,8 +36,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ess.logging.configure(level=logging.DEBUG, root='overwrite')\n",
+    "ess.logging.configure(level=logging.DEBUG, root=False)\n",
     "ess.logging.greet()\n",
+    "logger = ess.get_logger('amor_reduction')\n",
     "sc.display_logs()"
    ]
   },
@@ -103,6 +104,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "logger.info('Loading primary data file')\n",
     "sample = amor.load(amor.data.get_path(\"sample.nxs\"),\n",
     "                   beamline=amor_beamline)\n",
     "sample"
@@ -151,6 +153,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "logger.info(\"Correcting pixel positions for 'sample.nxs'\")\n",
     "def pixel_position_correction(data: sc.DataArray):\n",
     "    return data.coords['position'].fields.z * sc.tan(2.0 *\n",
     "                                                     data.coords['sample_rotation'] -\n",
@@ -326,6 +329,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "logger.info('Loading reference file for normalization')\n",
     "reference = amor.load(amor.data.get_path(\"reference.nxs\"),\n",
     "                      beamline=amor_beamline)\n",
     "reference.coords['position'].fields.y += pixel_position_correction(reference)\n",

--- a/docs/instruments/amor/amor_reduction.ipynb
+++ b/docs/instruments/amor/amor_reduction.ipynb
@@ -23,7 +23,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import logging\n",
     "import scipp as sc\n",
     "from ess import amor\n",
     "import ess"
@@ -36,10 +35,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ess.logging.configure(level=logging.DEBUG, root=False)\n",
-    "ess.logging.greet()\n",
-    "logger = ess.get_logger('amor_reduction')\n",
-    "sc.display_logs()"
+    "logger = ess.logging.configure_workflow('amor_reduction',\n",
+    "                                        filename='amor.log')"
    ]
   },
   {
@@ -153,7 +150,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "logger.info(\"Correcting pixel positions for 'sample.nxs'\")\n",
+    "logger.info(\"Correcting pixel positions in 'sample.nxs'\")\n",
     "def pixel_position_correction(data: sc.DataArray):\n",
     "    return data.coords['position'].fields.z * sc.tan(2.0 *\n",
     "                                                     data.coords['sample_rotation'] -\n",
@@ -495,8 +492,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.9.9"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/docs/techniques/wfm/introduction-to-wfm.ipynb
+++ b/docs/techniques/wfm/introduction-to-wfm.ipynb
@@ -1222,8 +1222,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.9.5"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/docs/techniques/wfm/reducing-wfm-data.ipynb
+++ b/docs/techniques/wfm/reducing-wfm-data.ipynb
@@ -975,8 +975,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.9.5"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/docs/utilities/utilities.rst
+++ b/docs/utilities/utilities.rst
@@ -1,0 +1,11 @@
+.. currentmodule:: ess
+
+Modules
+=======
+
+.. autosummary::
+   :toctree: ../generated/modules
+   :template: ess-module-template.rst
+   :recursive:
+
+   logging

--- a/src/ess/__init__.py
+++ b/src/ess/__init__.py
@@ -5,7 +5,7 @@ try:
     from . import _version
     __version__ = _version.__version__
 except ImportError:
-    pass
+    __version__ = "0.0.0-unknown"
 
 from . import amor
 from . import logging

--- a/src/ess/__init__.py
+++ b/src/ess/__init__.py
@@ -8,6 +8,7 @@ except ImportError:
     __version__ = "0.0.0-unknown"
 
 from . import amor
+from .logging import get_logger
 from . import logging
 from . import reflectometry
 from . import wfm

--- a/src/ess/__init__.py
+++ b/src/ess/__init__.py
@@ -8,5 +8,6 @@ except ImportError:
     pass
 
 from . import amor
+from . import logging
 from . import reflectometry
 from . import wfm

--- a/src/ess/amor/beamline.py
+++ b/src/ess/amor/beamline.py
@@ -6,7 +6,8 @@ from ..choppers import make_chopper
 from ..logging import log_call
 
 
-@log_call(instrument='amor', message='Constructing AMOR beamline parameters')
+@log_call(instrument='amor',
+          message='Constructing AMOR beamline from default parameters')
 def make_beamline(
     sample_rotation: sc.Variable = None,
     beam_size: sc.Variable = 0.001 * sc.units.m,

--- a/src/ess/amor/beamline.py
+++ b/src/ess/amor/beamline.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
-import logging
 import scipp as sc
 from scipp.constants import g
 from ..choppers import make_chopper
@@ -60,7 +59,7 @@ def make_beamline(
     return beamline
 
 
-@log_call(level=logging.DEBUG)
+@log_call(level='DEBUG')
 def instrument_view_components(da: sc.DataArray) -> dict:
     """
     Create a dict of instrument view components, containing:

--- a/src/ess/amor/beamline.py
+++ b/src/ess/amor/beamline.py
@@ -6,7 +6,7 @@ from ..choppers import make_chopper
 from ..logging import log_call
 
 
-@log_call(message='Constructing artificial AMOR beamline parameters')
+@log_call(message='Constructing AMOR beamline parameters')
 def make_beamline(
     sample_rotation: sc.Variable = None,
     beam_size: sc.Variable = 0.001 * sc.units.m,

--- a/src/ess/amor/beamline.py
+++ b/src/ess/amor/beamline.py
@@ -1,10 +1,13 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
+import logging
 import scipp as sc
 from scipp.constants import g
 from ..choppers import make_chopper
+from ..logging import log_call
 
 
+@log_call
 def make_beamline(
     sample_rotation: sc.Variable = None,
     beam_size: sc.Variable = 0.001 * sc.units.m,
@@ -57,6 +60,7 @@ def make_beamline(
     return beamline
 
 
+@log_call(level=logging.DEBUG)
 def instrument_view_components(da: sc.DataArray) -> dict:
     """
     Create a dict of instrument view components, containing:

--- a/src/ess/amor/beamline.py
+++ b/src/ess/amor/beamline.py
@@ -6,7 +6,7 @@ from ..choppers import make_chopper
 from ..logging import log_call
 
 
-@log_call(message='Constructing AMOR beamline parameters')
+@log_call(instrument='amor', message='Constructing AMOR beamline parameters')
 def make_beamline(
     sample_rotation: sc.Variable = None,
     beam_size: sc.Variable = 0.001 * sc.units.m,
@@ -59,7 +59,7 @@ def make_beamline(
     return beamline
 
 
-@log_call(level='DEBUG')
+@log_call(instrument='amor', level='DEBUG')
 def instrument_view_components(da: sc.DataArray) -> dict:
     """
     Create a dict of instrument view components, containing:

--- a/src/ess/amor/beamline.py
+++ b/src/ess/amor/beamline.py
@@ -7,7 +7,7 @@ from ..choppers import make_chopper
 from ..logging import log_call
 
 
-@log_call
+@log_call(message='Constructing artificial AMOR beamline parameters')
 def make_beamline(
     sample_rotation: sc.Variable = None,
     beam_size: sc.Variable = 0.001 * sc.units.m,

--- a/src/ess/amor/load.py
+++ b/src/ess/amor/load.py
@@ -31,7 +31,7 @@ def _tof_correction(data: sc.DataArray, dim: str = 'tof') -> sc.DataArray:
 
 def load(filename,
          beamline: Optional[dict] = None,
-         disable_warnings: bool = True) -> sc.DataArray:
+         disable_warnings: Optional[bool] = True) -> sc.DataArray:
     """
     Loader for a single Amor data file.
 

--- a/src/ess/amor/load.py
+++ b/src/ess/amor/load.py
@@ -1,10 +1,11 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
 from typing import Optional
+import warnings
 import scipp as sc
 import scippneutron as scn
 from .beamline import make_beamline
-import warnings
+from ..logging import get_logger
 
 
 def _tof_correction(data: sc.DataArray, dim: str = 'tof') -> sc.DataArray:
@@ -34,10 +35,14 @@ def load(filename,
     """
     Loader for a single Amor data file.
 
+    :param filename: Path of the file to load.
     :param beamline: A dict defining the beamline parameters.
     :param disable_warnings: Do not show warnings from file loading if `True`.
         Default is `True`.
     """
+    get_logger('amor').info(
+        "Loading '%s' as an Amor NeXus file",
+        filename.filename if hasattr(filename, 'filename') else filename)
     if disable_warnings:
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=UserWarning)

--- a/src/ess/amor/load.py
+++ b/src/ess/amor/load.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
+from typing import Optional
 import scipp as sc
 import scippneutron as scn
 from .beamline import make_beamline
@@ -28,7 +29,7 @@ def _tof_correction(data: sc.DataArray, dim: str = 'tof') -> sc.DataArray:
 
 
 def load(filename,
-         beamline: dict = make_beamline(),
+         beamline: Optional[dict] = None,
          disable_warnings: bool = True) -> sc.DataArray:
     """
     Loader for a single Amor data file.
@@ -53,6 +54,7 @@ def load(filename,
     data.coords['tof'] = sc.to_unit(data.coords['tof'], 'us', copy=False)
 
     # Add beamline parameters
+    beamline = make_beamline() if beamline is None else beamline
     for key, value in beamline.items():
         data.coords[key] = value
 

--- a/src/ess/logging.py
+++ b/src/ess/logging.py
@@ -49,6 +49,7 @@ def _function_name(f: Callable) -> str:
 
 def log_call(func: Optional[Callable] = None,
              *,
+             message: str = None,
              instrument: Optional[str] = None,
              level: int = logging.INFO):
     """Decorator that logs a message every time the function is called.
@@ -62,7 +63,10 @@ def log_call(func: Optional[Callable] = None,
 
         @functools.wraps(f)
         def impl(*args, **kwargs):
-            get_logger(inst).log(level, 'Calling %s', _function_name(f))
+            if message is not None:
+                get_logger(inst).log(level, message)
+            else:
+                get_logger(inst).log(level, 'Calling %s', _function_name(f))
             return f(*args, **kwargs)
 
         return impl

--- a/src/ess/logging.py
+++ b/src/ess/logging.py
@@ -14,13 +14,15 @@ import scipp as sc
 import scippneutron as scn
 
 
-def get_logger(instrument: Optional[str] = None) -> logging.Logger:
+def get_logger(subname: Optional[str] = None) -> logging.Logger:
     """Return one of ess's loggers.
 
-    :param instrument: If given, return the logger for the specified instrument.
-                       Otherwise, return the general ess logger.
+    :param subname: Name of an instrument, technique, or workflow.
+                    If given, return the logger with the given name
+                    as a child of the ess logger.
+                    Otherwise, return the general ess logger.
     """
-    name = 'scipp.ess' + ('.' + instrument if instrument else '')
+    name = 'scipp.ess' + ('.' + subname if subname else '')
     return logging.getLogger(name)
 
 

--- a/src/ess/logging.py
+++ b/src/ess/logging.py
@@ -193,6 +193,7 @@ def greet():
     # Import here so we don't import from a partially built package.
     from . import __version__
     get_logger().info(
-        '''ess: %s (https://scipp.github.io/ess/)
+        '''Software Versions:
+ess: %s (https://scipp.github.io/ess/)
 scippneutron: %s (https://scipp.github.io/scippneutron/)
 scipp: %s (https://scipp.github.io/)''', __version__, scn.__version__, sc.__version__)

--- a/src/ess/logging.py
+++ b/src/ess/logging.py
@@ -52,7 +52,6 @@ def log_call(func: Optional[Callable] = None,
     Tries to deduce the instrument name from the module of `func`.
     This can be overridden by specifying a name explicitly.
     """
-
     def deco(f: Callable):
         inst = _deduce_instrument_name(f) if instrument is None else instrument
 
@@ -75,7 +74,6 @@ class Formatter(logging.Formatter):
     """
     Logging formatter that indents messages and optionally shows threading information.
     """
-
     def __init__(self, show_thread: bool, show_process: bool):
         """
         Initialize the formatter.

--- a/src/ess/logging.py
+++ b/src/ess/logging.py
@@ -51,7 +51,6 @@ def log_call(*,
     level = logging.getLevelName(level) if isinstance(level, str) else level
 
     def deco(f: Callable):
-
         @functools.wraps(f)
         def impl(*args, **kwargs):
             if message is not None:
@@ -69,7 +68,6 @@ class Formatter(logging.Formatter):
     """
     Logging formatter that indents messages and optionally shows threading information.
     """
-
     def __init__(self, show_thread: bool, show_process: bool):
         """
         Initialize the formatter.

--- a/src/ess/logging.py
+++ b/src/ess/logging.py
@@ -99,7 +99,7 @@ def _make_formatter(show_thread: bool, show_process: bool) -> logging.Formatter:
     fmt_pre = '[%(asctime)s] %(levelname)-8s '
     fmt_post = '<%(name)s> : %(message)s'
     fmt = fmt_pre + ('{' + fmt_proc_thread + '} ' if fmt_proc_thread else '') + fmt_post
-    return logging.Formatter(fmt, datefmt='%Y-%m-%dT%H:%M:%S')
+    return logging.Formatter(fmt, datefmt='%Y-%m-%dT%H:%M:%S%z')
 
 
 def _make_stream_handler(level: Union[str, int], show_thread: bool,

--- a/src/ess/logging.py
+++ b/src/ess/logging.py
@@ -95,7 +95,8 @@ def default_loggers_to_configure() -> List[logging.Logger]:
     ]
 
 
-def configure(filename: Optional[Union[str, PathLike]] = 'scipp.ess.log',
+def configure(*,
+              filename: Optional[Union[str, PathLike]] = 'scipp.ess.log',
               file_level: Union[str, int] = logging.INFO,
               stream_level: Union[str, int] = logging.WARNING,
               widget_level: Union[str, int] = logging.INFO,
@@ -121,6 +122,17 @@ def configure(filename: Optional[Union[str, PathLike]] = 'scipp.ess.log',
     for logger in loggers:
         _configure_logger(logger, handlers, base_level)
     # TODO mantid's own config
+
+
+def configure_workflow(workflow_name: Optional[str]=None, *, display:bool=True, **kwargs):
+    """
+    TODO
+    """
+    configure(**kwargs)
+    greet()
+    if display:
+        sc.display_logs()
+    return get_logger(workflow_name)
 
 
 def greet():

--- a/src/ess/logging.py
+++ b/src/ess/logging.py
@@ -52,6 +52,7 @@ def log_call(func: Optional[Callable] = None,
     Tries to deduce the instrument name from the module of `func`.
     This can be overridden by specifying a name explicitly.
     """
+
     def deco(f: Callable):
         inst = _deduce_instrument_name(f) if instrument is None else instrument
         nonlocal level
@@ -76,6 +77,7 @@ class Formatter(logging.Formatter):
     """
     Logging formatter that indents messages and optionally shows threading information.
     """
+
     def __init__(self, show_thread: bool, show_process: bool):
         """
         Initialize the formatter.
@@ -156,6 +158,11 @@ def configure(*,
     :param loggers: Collection of loggers or names of loggers to configure.
                     If not given, uses :py:func:`default_loggers_to_configure`.
     """
+    if configure.is_configured:
+        get_logger().warning(
+            'Called `logging.configure` but logging is already configured')
+        return
+
     handlers = _make_handlers(filename, file_level, stream_level, widget_level,
                               show_thread, show_process)
     base_level = _base_level([file_level, stream_level, widget_level])
@@ -166,6 +173,11 @@ def configure(*,
     for logger in loggers:
         _configure_logger(logger, handlers, base_level)
     # TODO mantid's own config
+
+    configure.is_configured = True
+
+
+configure.is_configured = False
 
 
 def configure_workflow(workflow_name: Optional[str] = None,

--- a/src/ess/logging.py
+++ b/src/ess/logging.py
@@ -130,6 +130,12 @@ def greet():
     """Log a message showing the versions of important packages."""
     # TODO mantid? what if not used in workflow?
     # TODO add scn.greet()?
+    # Import here so we don't import from a partially built package.
     from . import __version__
-    get_logger().info('ESS v%s\nscippneutron v%s\nscipp v%s', __version__,
-                      scn.__version__, sc.__version__)
+    get_logger().info(
+        '''ess: %s (https://scipp.github.io/ess/)
+scippneutron: %s (https://scipp.github.io/scippneutron/)
+scipp: %s (https://scipp.github.io/)''', __version__, scn.__version__, sc.__version__)
+
+
+# TODO store file name in datasets?

--- a/src/ess/logging.py
+++ b/src/ess/logging.py
@@ -45,7 +45,7 @@ def log_call(func: Optional[Callable] = None,
              *,
              message: str = None,
              instrument: Optional[str] = None,
-             level: int = logging.INFO):
+             level: Union[int, str] = logging.INFO):
     """
     Decorator that logs a message every time the function is called.
 

--- a/src/ess/logging.py
+++ b/src/ess/logging.py
@@ -130,8 +130,8 @@ def configure(*,
     This function is meant as a helper for application (or notebook) developers.
     It configures the loggers of ess, scippneutron, scipp, and some
     third party packages.
-    *Calling it from a library should be avoided because*
-    it can mess up a user's setup.
+    *Calling it from a library should be avoided*
+    because it can mess up a user's setup.
 
     Up to 3 handlers are configured:
 
@@ -143,7 +143,7 @@ def configure(*,
 
     :param filename: Name of the log file.
                      Overwrites existing files.
-                     Settings this to `None` disables logging to file.
+                     Setting this to `None` disables logging to file.
     :param file_level: Log level for the file handler.
     :param stream_level: Log level for the stream handler.
     :param widget_level: Log level for the widget handler.

--- a/src/ess/logging.py
+++ b/src/ess/logging.py
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2022 Scipp contributors (https://github.com/scipp)
+# @author Jan-Lukas Wynen
+
+import functools
+import logging
+import inspect
+from typing import Any, Callable, Optional
+
+import scipp as sc
+import scippneutron as scn
+
+
+def get_logger(instrument: Optional[str] = None) -> logging.Logger:
+    """Return one of ess's loggers.
+
+    :param instrument: If given, return the logger for the specified instrument.
+                       Otherwise, return the general ess logger.
+    """
+    name = 'scipp.ess' + ('.' + instrument if instrument else '')
+    return logging.getLogger(name)
+
+
+_INSTRUMENTS = ['amor', 'beer', 'bifrost', 'cspec', 'dream', 'estia', 'freia', 'heimdal', 'loki',
+                'magic', 'miracles', 'nmx', 'odin', 'skadi', 'trex', 'v20', 'vespa']
+
+
+def _deduce_instrument_name(f: Any) -> Optional[str]:
+    # Assumes package name: ess.<instrument>[.subpackage]
+    package = inspect.getmodule(f).__package__
+    components = package.split('.', 2)
+    try:
+        if components[0] == 'ess':
+            candidate = components[1]
+            if candidate in _INSTRUMENTS:
+                return candidate
+    except IndexError:
+        pass
+    return None
+
+
+def _function_name(f: Callable) -> str:
+    if hasattr(f, '__module__'):
+        return f'{f.__module__}.{f.__name__}'
+    return f.__name__
+
+
+def log_call(func: Optional[Callable] = None, *, instrument: Optional[str] = None,
+             level: int = logging.INFO):
+    """Decorator that logs a message every time the function is called.
+
+    Tries to deduce the instrument name from the module of `func`.
+    This can be overridden by specifying a name explicitly.
+    """
+
+    def deco(f: Callable):
+        inst = _deduce_instrument_name(f) if instrument is None else instrument
+
+        @functools.wraps(f)
+        def impl(*args, **kwargs):
+            get_logger(inst).log(level, 'Calling %s', _function_name(f))
+            return f(*args, **kwargs)
+
+        return impl
+
+    if func is None:
+        return deco
+    return deco(func)
+
+
+def set_level_all(logger: logging.Logger, level: int):
+    """Sets a log level for a logger and all its handlers."""
+    logger.setLevel(level)
+    for handler in logger.handlers:
+        handler.setLevel(level)
+
+
+def _handle_same_as_scipp(logger: logging.Logger):
+    for handler in list(logger.handlers):
+        logger.removeHandler(handler)
+    for handler in sc.get_logger().handlers:
+        logger.addHandler(handler)
+
+
+def _configure_3rd_party(logger: logging.Logger, level: int):
+    _handle_same_as_scipp(logger)
+    set_level_all(logger, level)
+
+
+def configure(level: int = logging.INFO):
+    """Set up logging for the ess package.
+
+    This function is meant as a helper for application (or notebook) developers.
+    It configures the loggers of ess, scippneutron, scipp, and some third party packages.
+    Calling it from a library can thus mess up a user's setup.
+    """
+    import pooch
+
+    set_level_all(sc.get_logger(), level)
+
+    _configure_3rd_party(pooch.get_logger(), level)
+    # TODO mantid's own config
+    _configure_3rd_party(logging.getLogger('Mantid'), level)
+
+    # TODO file, console (stdlog or stderr?)
+
+
+def greet():
+    """Log a message showing the versions of important packages."""
+    # TODO mantid? what if not used in workflow?
+    # TODO add scn.greet()?
+    from . import __version__
+    get_logger().info('ESS v%s\nscippneutron v%s\nscipp v%s',
+                      __version__, scn.__version__, sc.__version__)

--- a/src/ess/logging.py
+++ b/src/ess/logging.py
@@ -6,13 +6,11 @@ import functools
 import logging.config
 import logging
 import inspect
-import re
 from os import PathLike
-from typing import Any, Callable, Literal, MutableMapping, Optional, Union
+from typing import Any, Callable, List, Literal, Optional, Union
 
 import scipp as sc
 import scippneutron as scn
-import structlog
 
 
 def get_logger(instrument: Optional[str] = None) -> logging.Logger:
@@ -96,7 +94,6 @@ def _make_stream_handler(level: Union[str, int]) -> logging.StreamHandler:
     return handler
 
 
-# TODO share handler?
 def _make_file_handler(filename: Union[str, PathLike],
                        level: Union[str, int]) -> logging.FileHandler:
     handler = logging.FileHandler(filename, mode='w')
@@ -107,23 +104,25 @@ def _make_file_handler(filename: Union[str, PathLike],
     return handler
 
 
-def _configure_root(level, filename, reset):
+def _make_widget_handler(level: Union[str, int]) -> sc.logging.WidgetHandler:
+    return sc.logging.WidgetHandler(level=level, widget=sc.logging.LogWidget())
+
+
+def _configure_root(handlers: List[logging.Handler], level: Union[str, int], reset):
     root = logging.getLogger()
     if reset:
-        for handler in root.handlers:
+        for handler in list(root.handlers):
             root.removeHandler(handler)
+        for filt in list(root.filters):
+            root.removeFilter(filt)
 
-    _configure_logger(root, filename, level)
+    _configure_logger(root, handlers, level)
 
 
-# TODO separate levels for handlers
-def _configure_logger(logger: logging.Logger, filename: Optional[Union[str, PathLike]],
+def _configure_logger(logger: logging.Logger, handlers: List[logging.Handler],
                       level: Union[str, int]):
-    logger.addHandler(_make_stream_handler(level))
-    if filename is not None:
-        logger.addHandler(_make_file_handler(filename, level))
-    # TODO make it work when not in Jupyter
-    logger.addHandler(sc.logging.get_widget_handler())
+    for handler in handlers:
+        logger.addHandler(handler)
     logger.setLevel(level)
 
 
@@ -138,21 +137,26 @@ def _thread_name_abbreviator(logger: logging.Logger, method_name: str,
             event_dict['thread_name'] = match[1]
     return event_dict
 
+def _make_handlers(filename: Optional[Union[str, PathLike]],
+                   file_level: Union[str, int], stream_level: Union[str, int],
+                   widget_level: Union[str, int]) -> List[logging.Handler]:
+    handlers = [_make_stream_handler(stream_level)]
+    if filename is not None:
+        handlers.append(_make_file_handler(filename, file_level))
+    if sc.utils.running_in_jupyter():
+        handlers.append(_make_widget_handler(widget_level))
+    return handlers
 
-def _key_value_inserter(logger, method_name, event_dict):
-    aux = dict(event_dict)
-    del aux['timestamp']
-    del aux['level']
-    del aux['logger']
-    del aux['event']
-    rend = structlog.processors.KeyValueRenderer()(logger, method_name, aux)
-    if rend:
-        event_dict['event'] += ' ' + rend
-    return event_dict
+
+def _base_level(levels: List[Union[str, int]]) -> int:
+    return min((logging.getLevelName(level) if isinstance(level, str) else level
+                for level in levels))
 
 
 def configure(filename: Optional[Union[str, PathLike]] = 'scipp.ess.log',
-              level: Union[str, int] = logging.INFO,
+              file_level: Union[str, int] = logging.INFO,
+              stream_level: Union[str, int] = logging.WARNING,
+              widget_level: Union[str, int] = logging.INFO,
               root: Union[bool, Literal['yes', 'no', 'overwrite']] = False):
     """Set up logging for the ess package.
 
@@ -163,93 +167,15 @@ def configure(filename: Optional[Union[str, PathLike]] = 'scipp.ess.log',
 
     TODO details
     """
-    timestamper = structlog.processors.TimeStamper(fmt='%Y-%m-%dT%H:%M:%S')
-    callsite_param_adder = structlog.processors.CallsiteParameterAdder(
-        {structlog.processors.CallsiteParameter.THREAD_NAME})
-    foreign_pre_chain = [
-        timestamper,
-        structlog.stdlib.add_log_level,
-        structlog.stdlib.add_logger_name,
-        structlog.stdlib.ExtraAdder(),
-        callsite_param_adder,
-        _thread_name_abbreviator,
-    ]
-    logging.config.dictConfig({
-        'version': 1,
-        'disable_existing_loggers': False,
-        'incremental': False,  # TODO good choice?
-        'formatters': {
-            'plain': {
-                '()': 'logging.Formatter',
-                # TODO thread?
-                'format': '[%(asctime)s] <%(name)s> %(levelname)-8s : %(message)s',
-                'datefmt': '%Y-%m-%dT%H:%M:%S',
-            },
-            'json': {
-                '()':
-                structlog.stdlib.ProcessorFormatter,
-                'processors': [
-                    # TODO currently prints both logging and structlog fields
-                    structlog.stdlib.ProcessorFormatter.remove_processors_meta,
-                    structlog.processors.JSONRenderer(),
-                ],
-                'foreign_pre_chain':
-                foreign_pre_chain,
-            },
-        },
-        'handlers': {
-            'stream': {
-                'level': 'INFO',
-                'class': 'logging.StreamHandler',
-                'formatter': 'plain',
-            },
-            'json_file': {
-                'level': 'INFO',
-                'class': 'logging.FileHandler',
-                'formatter': 'json',
-                'filename': 'test.log.json',
-            },
-        },
-        'loggers': {
-            '': {
-                'handlers': ['stream', 'json_file'],
-                'level': 'INFO',
-                'propagate': True,
-            }
-        }
-    })
-    structlog.configure(
-        processors=[
-            structlog.stdlib.filter_by_level,
-            # add timestamp, level, name even though logging handles them separately
-            # need them for the JSON formatter
-            timestamper,
-            structlog.stdlib.add_log_level,
-            structlog.stdlib.add_logger_name,
-            structlog.stdlib.PositionalArgumentsFormatter(),
-            structlog.processors.StackInfoRenderer(),
-            structlog.processors.format_exc_info,
-            structlog.processors.UnicodeDecoder(),
-            callsite_param_adder,
-            # _thread_name_abbreviator,
-            # structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
-            _key_value_inserter,
-            structlog.stdlib.render_to_log_kwargs,
-        ],
-        logger_factory=structlog.stdlib.LoggerFactory(),
-        wrapper_class=structlog.stdlib.BoundLogger,
-        cache_logger_on_first_use=True,
-    )
-
-    return
+    handlers = _make_handlers(filename, file_level, stream_level, widget_level)
+    base_level = _base_level([file_level, stream_level, widget_level])
     if root is True or root in ('yes', 'overwrite'):
-        _configure_root(level, filename, reset=root == 'overwrite')
+        _configure_root(handlers, base_level, reset=root == 'overwrite')
     # TODO don't configure twice -> update scipp
-    _configure_logger(sc.get_logger(), filename, level)
     import pooch
-    _configure_logger(pooch.get_logger(), filename, level)
+    for logger in (sc.get_logger(), pooch.get_logger(), logging.getLogger('Mantid')):
+        _configure_logger(logger, handlers, base_level)
     # TODO mantid's own config
-    _configure_logger(logging.getLogger('Mantid'), filename, level)
 
 
 def greet():
@@ -262,7 +188,3 @@ def greet():
         '''ess: %s (https://scipp.github.io/ess/)
 scippneutron: %s (https://scipp.github.io/scippneutron/)
 scipp: %s (https://scipp.github.io/)''', __version__, scn.__version__, sc.__version__)
-
-
-# TODO time zone in logs
-# TODO store file name in datasets?

--- a/src/ess/logging.py
+++ b/src/ess/logging.py
@@ -78,9 +78,10 @@ class Formatter(logging.Formatter):
         """
         Initialize the formatter.
 
-        The general as well as date formats are fixed.
-        But the arguments can be used to toggle printing of
-        thread and processor names.
+        The formatting is mostly fixed.
+        Only printing of thread and processor names cna be toggled using the
+        corresponding arguments.
+        Times are always printed in ISO 8601 format.
         """
         fmt_proc = '%(processName)s' if show_process else ''
         fmt_thread = '%(threadName)s' if show_thread else ''

--- a/src/ess/logging.py
+++ b/src/ess/logging.py
@@ -172,7 +172,7 @@ configure.is_configured = False
 
 def configure_workflow(workflow_name: Optional[str] = None,
                        *,
-                       display: bool = running_in_jupyter(),
+                       display: Optional[bool] = None,
                        **kwargs) -> logging.Logger:
     """
     Configure logging for a reduction workflow.
@@ -187,7 +187,7 @@ def configure_workflow(workflow_name: Optional[str] = None,
     """
     configure(**kwargs)
     greet()
-    if display:
+    if (display is None and running_in_jupyter()) or display:
         sc.display_logs()
     return get_logger(workflow_name)
 

--- a/src/ess/logging.py
+++ b/src/ess/logging.py
@@ -54,6 +54,8 @@ def log_call(func: Optional[Callable] = None,
     """
     def deco(f: Callable):
         inst = _deduce_instrument_name(f) if instrument is None else instrument
+        nonlocal level
+        level = logging.getLevelName(level) if isinstance(level, str) else level
 
         @functools.wraps(f)
         def impl(*args, **kwargs):

--- a/src/ess/logging.py
+++ b/src/ess/logging.py
@@ -52,7 +52,6 @@ def log_call(func: Optional[Callable] = None,
     Tries to deduce the instrument name from the module of `func`.
     This can be overridden by specifying a name explicitly.
     """
-
     def deco(f: Callable):
         inst = _deduce_instrument_name(f) if instrument is None else instrument
         nonlocal level
@@ -77,7 +76,6 @@ class Formatter(logging.Formatter):
     """
     Logging formatter that indents messages and optionally shows threading information.
     """
-
     def __init__(self, show_thread: bool, show_process: bool):
         """
         Initialize the formatter.

--- a/src/ess/logging.py
+++ b/src/ess/logging.py
@@ -41,41 +41,35 @@ def get_logger(subname: Optional[str] = None) -> logging.Logger:
     return logging.getLogger(name)
 
 
-def log_call(func: Optional[Callable] = None,
-             *,
+def log_call(*,
+             instrument: str,
              message: str = None,
-             instrument: Optional[str] = None,
              level: Union[int, str] = logging.INFO):
     """
     Decorator that logs a message every time the function is called.
-
-    Tries to deduce the instrument name from the module of `func`.
-    This can be overridden by specifying a name explicitly.
     """
+    level = logging.getLevelName(level) if isinstance(level, str) else level
+
     def deco(f: Callable):
-        inst = _deduce_instrument_name(f) if instrument is None else instrument
-        nonlocal level
-        level = logging.getLevelName(level) if isinstance(level, str) else level
 
         @functools.wraps(f)
         def impl(*args, **kwargs):
             if message is not None:
-                get_logger(inst).log(level, message)
+                get_logger(instrument).log(level, message)
             else:
-                get_logger(inst).log(level, 'Calling %s', _function_name(f))
+                get_logger(instrument).log(level, 'Calling %s', _function_name(f))
             return f(*args, **kwargs)
 
         return impl
 
-    if func is None:
-        return deco
-    return deco(func)
+    return deco
 
 
 class Formatter(logging.Formatter):
     """
     Logging formatter that indents messages and optionally shows threading information.
     """
+
     def __init__(self, show_thread: bool, show_process: bool):
         """
         Initialize the formatter.

--- a/src/ess/logging.py
+++ b/src/ess/logging.py
@@ -186,14 +186,23 @@ def configure(filename: Optional[Union[str, PathLike]] = 'scipp.ess.log',
     # TODO mantid's own config
 
 
+def _mantid_version() -> Optional[str]:
+    try:
+        import mantid
+        return mantid.__version__
+    except ImportError:
+        return None
+
+
 def greet():
     """Log a message showing the versions of important packages."""
-    # TODO mantid? what if not used in workflow?
-    # TODO add scn.greet()?
     # Import here so we don't import from a partially built package.
     from . import __version__
-    get_logger().info(
-        '''Software Versions:
-ess: %s (https://scipp.github.io/ess/)
-scippneutron: %s (https://scipp.github.io/scippneutron/)
-scipp: %s (https://scipp.github.io/)''', __version__, scn.__version__, sc.__version__)
+    msg = f'''Software Versions:
+ess: {__version__} (https://scipp.github.io/ess)
+scippneutron: {scn.__version__} (https://scipp.github.io/scippneutron)
+scipp: {sc.__version__} (https://scipp.github.io)'''
+    mantid_version = _mantid_version()
+    if mantid_version:
+        msg += f'\nMantid: {mantid_version} (https://www.mantidproject.org)'
+    get_logger().info(msg)


### PR DESCRIPTION
Implements logging for reflectometry and Amor.
This will probably need many iterations to figure out what, how, and where to log. But the high level API (`get_logger`, `configure[_workflow]`) should be kind of final when the PR is merged so that we can start using it across techniques. Please take that into account when reviewing.

The  TODO about Mantid can only be resolved when Mantid 6.4 is released which provides an API to forward its logs to Python.