### PR TITLE
No longer import all submodules at the top level of the `ess` package

### DIFF
--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -12,6 +12,8 @@ Features
 Breaking changes
 ~~~~~~~~~~~~~~~~
 
+* When doing ``import ess``, all the submodules (``amor``, ``reflectometry``, and ``wfm``) are no longer directly available as ``ess.amor``. Instead, we now rely on simply doing ``from ess import amor`` or ``import ess.sans as sans`` `#102 <https://github.com/scipp/ess/pull/102>`_.
+
 Bugfixes
 ~~~~~~~~
 

--- a/src/ess/__init__.py
+++ b/src/ess/__init__.py
@@ -7,8 +7,5 @@ try:
 except ImportError:
     __version__ = "0.0.0-unknown"
 
-from . import amor
 from .logging import get_logger
 from . import logging
-from . import reflectometry
-from . import wfm


### PR DESCRIPTION
With these changes, when doing `import ess`, we are no longer importing all the submodules (`amor`, `reflectometry`, `wfm`).
We now rely on simply doing `from ess import amor` or `import ess.sans as sans`.

Fixes #98 