### PR TITLE
Use <div> instead of <a> tag for citation links to work in sphinx

### DIFF
--- a/docs/instruments/loki/sans2d_reduction.ipynb
+++ b/docs/instruments/loki/sans2d_reduction.ipynb
@@ -458,7 +458,8 @@
    "id": "88bd6494-80f4-4bf7-b026-f14a1849bf53",
    "metadata": {},
    "source": [
-    "<a id='manasi2021'></a>\n",
+    "<div id=\"manasi2021\"></div>\n",
+    "\n",
     "Manasi I., Andalibi M. R., Atri R. S., Hooton J., King S. M., Edler K. J., **2021**,\n",
     "*Self-assembly of ionic and non-ionic surfactants in type IV cerium nitrate and urea based deep eutectic solvent*,\n",
     "[J. Chem. Phys. 155, 084902](https://doi.org/10.1063/5.0059238)"

--- a/docs/instruments/loki/sans2d_to_I_of_Q.ipynb
+++ b/docs/instruments/loki/sans2d_to_I_of_Q.ipynb
@@ -699,10 +699,11 @@
    "id": "faf45578-6b6a-4046-82aa-4864a2e8bb8b",
    "metadata": {},
    "source": [
+    "<div id='heenan1997'></div>\n",
+    "\n",
     "Heenan R. K., Penfold J., King S. M., **1997**,\n",
     "*SANS at Pulsed Neutron Sources: Present and Future Prospects*,\n",
-    "[J. Appl. Cryst., 30, 1140-1147](https://doi.org/10.1107/S0021889897002173)\n",
-    "<a id='heenan1997'></a>"
+    "[J. Appl. Cryst., 30, 1140-1147](https://doi.org/10.1107/S0021889897002173)"
    ]
   },
   {
@@ -710,7 +711,8 @@
    "id": "4ca6948e-ed72-49de-8529-4faf1474535c",
    "metadata": {},
    "source": [
-    "<a id='manasi2021'></a>\n",
+    "<div id='manasi2021'></div>\n",
+    "\n",
     "Manasi I., Andalibi M. R., Atri R. S., Hooton J., King S. M., Edler K. J., **2021**,\n",
     "*Self-assembly of ionic and non-ionic surfactants in type IV cerium nitrate and urea based deep eutectic solvent*,\n",
     "[J. Chem. Phys. 155, 084902](https://doi.org/10.1063/5.0059238)"
@@ -721,7 +723,8 @@
    "id": "9d8de3c2-6905-4cb8-99a1-8b4fd5973287",
    "metadata": {},
    "source": [
-    "<a id='seeger1991'></a>\n",
+    "<div id='seeger1991'></div>\n",
+    "\n",
     "Seeger P. A., Hjelm R. P. Jnr, **1991**,\n",
     "*Small-angle neutron scattering at pulsed spallation sources*,\n",
     "[J. Appl. Cryst., 24, 467-478](https://doi.org/10.1107/S0021889891004764)"

--- a/docs/techniques/wfm/introduction-to-wfm.ipynb
+++ b/docs/techniques/wfm/introduction-to-wfm.ipynb
@@ -1218,7 +1218,8 @@
    "id": "af184fcb-8431-4ed7-80f2-1fee0e82e229",
    "metadata": {},
    "source": [
-    "<a id='schmakat2020'></a>\n",
+    "<div id=\"schmakat2020\"></div>\n",
+    "\n",
     "Schmakat P., Seifert M., Schulz M., Tartaglione A., Lerche M., Morgano M., Böni P., Strobl M., **2020**,\n",
     "*Wavelength frame multiplication chopper system for the multi-purpose neutron-imaging instrument ODIN at the European Spallation Source*,\n",
     "[Nuclear Instruments and Methods in Physics Research Section A: Accelerators, Spectrometers, Detectors and Associated Equipment, 979, 164467](https://doi.org/10.1016/j.nima.2020.164467)"


### PR DESCRIPTION
Hyperlinks from `author names (date)` to the references section at the bottom of the notebook should now work in the sphinx docs.
Previously, the `<a>` tags only worked inside the jupyter notebooks.