### PR TITLE
Build docs in separate step

### DIFF
--- a/.github/workflows/pr_and_main.yml
+++ b/.github/workflows/pr_and_main.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           commit_message: Apply automatic formatting
 
-  build:
+  conda_build:
     needs: formatting
     runs-on: ubuntu-latest
     # env:
@@ -58,7 +58,7 @@ jobs:
       #     path: ${{ env.DOCS_HTML_DIR }}
 
   tests_and_docs:
-    needs: build
+    needs: conda_build
     runs-on: ubuntu-latest
     env:
       DOCS_HTML_DIR: ${{ github.workspace }}/docs_html
@@ -71,8 +71,6 @@ jobs:
       - uses: mamba-org/provision-with-micromamba@main
         with:
           environment-file: docs/environment.yml
-          activate-environment: ess-docs-build
-          auto-activate-base: false
           cache-env: true
       - run: mamba install conda-package-*/*/*.tar.bz2
       - run: python -m pytest -v tests

--- a/.github/workflows/pr_and_main.yml
+++ b/.github/workflows/pr_and_main.yml
@@ -72,7 +72,7 @@ jobs:
         with:
           environment-file: docs/environment.yml
           cache-env: true
-      - run: micromamba install conda-package-*/*/*.tar.bz2
+      - run: micromamba install noarch/ess*.tar.bz2
       - run: python -m pytest -v tests
       - run: python docs/make_docs.py
 

--- a/.github/workflows/pr_and_main.yml
+++ b/.github/workflows/pr_and_main.yml
@@ -75,7 +75,7 @@ jobs:
           activate-environment: ess-docs-build
           auto-activate-base: false
       - uses: actions/download-artifact@v2
-      - run: mamba install noarch/ess*.tar.bz2
+      - run: mamba install conda-package-*/*/*.tar.bz2 # noarch/ess*.tar.bz2
 
       # - uses: mamba-org/provision-with-micromamba@main
       #   with:

--- a/.github/workflows/pr_and_main.yml
+++ b/.github/workflows/pr_and_main.yml
@@ -36,21 +36,46 @@ jobs:
   build:
     needs: formatting
     runs-on: ubuntu-latest
-    env:
-      DOCS_HTML_DIR: ${{ github.workspace }}/docs_html
+    # env:
+    #   DOCS_HTML_DIR: ${{ github.workspace }}/docs_html
     steps:
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0  # history required so cmake can determine version
-      - uses: conda-incubator/setup-miniconda@v2
-      - run: conda install --channel conda-forge --yes conda-build mamba boa
+      - uses: mamba-org/provision-with-micromamba@main
+      - run: mamba install --channel conda-forge --yes conda-build mamba boa
       - run: conda mambabuild --channel conda-forge --channel scipp --channel mantid --no-anaconda-upload --override-channels --output-folder conda/package conda
 
       - uses: actions/upload-artifact@v2
         with:
           name: conda-package-ess
           path: conda/package/*/ess*.tar.bz2
+
+      # - uses: actions/upload-artifact@v2
+      #   with:
+      #     name: DocumentationHTML
+      #     path: ${{ env.DOCS_HTML_DIR }}
+
+  documentation:
+    needs: build
+    runs-on: ubuntu-latest
+    env:
+      DOCS_HTML_DIR: ${{ github.workspace }}/docs_html
+    steps:
+      - uses: actions/checkout@v2
+        # with:
+        #   ref: ${{ github.head_ref }}
+        #   fetch-depth: 0  # history required so cmake can determine version
+      - uses: actions/download-artifact@v2
+      - uses: mamba-org/provision-with-micromamba@main
+        with:
+          environment-file: docs/environment.yml
+          activate-environment: ess-docs-build
+          auto-activate-base: false
+          cache-env: true
+      - run: mamba install conda-package-*/*/*.tar.bz2
+      - run: python docs/make_docs.py
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/pr_and_main.yml
+++ b/.github/workflows/pr_and_main.yml
@@ -57,7 +57,7 @@ jobs:
       #     name: DocumentationHTML
       #     path: ${{ env.DOCS_HTML_DIR }}
 
-  documentation:
+  tests_and_docs:
     needs: build
     runs-on: ubuntu-latest
     env:
@@ -75,6 +75,7 @@ jobs:
           auto-activate-base: false
           cache-env: true
       - run: mamba install conda-package-*/*/*.tar.bz2
+      - run: python -m pytest -v tests
       - run: python docs/make_docs.py
 
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/pr_and_main.yml
+++ b/.github/workflows/pr_and_main.yml
@@ -43,8 +43,8 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0  # history required so cmake can determine version
-      - uses: mamba-org/provision-with-micromamba@main
-      - run: mamba install --channel conda-forge --yes conda-build mamba boa
+      - uses: conda-incubator/setup-miniconda@v2
+      - run: conda install --channel conda-forge --yes conda-build mamba boa
       - run: conda mambabuild --channel conda-forge --channel scipp --channel mantid --no-anaconda-upload --override-channels --output-folder conda/package conda
 
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/pr_and_main.yml
+++ b/.github/workflows/pr_and_main.yml
@@ -67,12 +67,22 @@ jobs:
         # with:
         #   ref: ${{ github.head_ref }}
         #   fetch-depth: 0  # history required so cmake can determine version
-      - uses: actions/download-artifact@v2
-      - uses: mamba-org/provision-with-micromamba@main
+      - uses: conda-incubator/setup-miniconda@v2
         with:
+          miniforge-version: latest
+          miniforge-variant: Mambaforge
           environment-file: docs/environment.yml
-          cache-env: true
-      - run: micromamba install noarch/ess*.tar.bz2
+          activate-environment: ess-docs-build
+          auto-activate-base: false
+      - uses: actions/download-artifact@v2
+      - run: mamba install noarch/ess*.tar.bz2
+
+      # - uses: mamba-org/provision-with-micromamba@main
+      #   with:
+      #     environment-file: docs/environment.yml
+      #     cache-env: true
+      # - run: micromamba install conda-package-*/*/*.tar.bz2
+
       - run: python -m pytest -v tests
       - run: python docs/make_docs.py
 

--- a/.github/workflows/pr_and_main.yml
+++ b/.github/workflows/pr_and_main.yml
@@ -72,7 +72,7 @@ jobs:
         with:
           environment-file: docs/environment.yml
           cache-env: true
-      - run: mamba install conda-package-*/*/*.tar.bz2
+      - run: micromamba install conda-package-*/*/*.tar.bz2
       - run: python -m pytest -v tests
       - run: python docs/make_docs.py
 

--- a/.github/workflows/pr_and_main.yml
+++ b/.github/workflows/pr_and_main.yml
@@ -36,8 +36,6 @@ jobs:
   conda_build:
     needs: formatting
     runs-on: ubuntu-latest
-    # env:
-    #   DOCS_HTML_DIR: ${{ github.workspace }}/docs_html
     steps:
       - uses: actions/checkout@v2
         with:
@@ -46,16 +44,10 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
       - run: conda install --channel conda-forge --yes conda-build mamba boa
       - run: conda mambabuild --channel conda-forge --channel scipp --channel mantid --no-anaconda-upload --override-channels --output-folder conda/package conda
-
       - uses: actions/upload-artifact@v2
         with:
           name: conda-package-ess
           path: conda/package/*/ess*.tar.bz2
-
-      # - uses: actions/upload-artifact@v2
-      #   with:
-      #     name: DocumentationHTML
-      #     path: ${{ env.DOCS_HTML_DIR }}
 
   tests_and_docs:
     needs: conda_build
@@ -64,9 +56,6 @@ jobs:
       DOCS_HTML_DIR: ${{ github.workspace }}/docs_html
     steps:
       - uses: actions/checkout@v2
-        # with:
-        #   ref: ${{ github.head_ref }}
-        #   fetch-depth: 0  # history required so cmake can determine version
       - uses: conda-incubator/setup-miniconda@v2
         with:
           miniforge-version: latest
@@ -75,14 +64,7 @@ jobs:
           activate-environment: ess-docs-build
           auto-activate-base: false
       - uses: actions/download-artifact@v2
-      - run: mamba install conda-package-*/*/*.tar.bz2 # noarch/ess*.tar.bz2
-
-      # - uses: mamba-org/provision-with-micromamba@main
-      #   with:
-      #     environment-file: docs/environment.yml
-      #     cache-env: true
-      # - run: micromamba install conda-package-*/*/*.tar.bz2
-
+      - run: mamba install conda-package-*/*/*.tar.bz2
       - run: python -m pytest -v tests
       - run: python docs/make_docs.py
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,23 +26,40 @@ jobs:
         with:
           commit_message: Apply automatic formatting
 
-  build:
+  conda_build:
     needs: formatting
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0  # history required so cmake can determine version
+      - uses: conda-incubator/setup-miniconda@v2
+      - run: conda install --channel conda-forge --yes conda-build mamba boa
+      - run: conda mambabuild --channel conda-forge --channel scipp --channel mantid --no-anaconda-upload --override-channels --output-folder conda/package conda
+      - uses: actions/upload-artifact@v2
+        with:
+          name: conda-package-ess
+          path: conda/package/*/ess*.tar.bz2
+
+  tests_and_docs:
+    needs: conda_build
     runs-on: ubuntu-latest
     env:
       DOCS_HTML_DIR: ${{ github.workspace }}/docs_html
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0  # history required so cmake can determine version
       - uses: conda-incubator/setup-miniconda@v2
-      - run: conda install --channel conda-forge --yes conda-build mamba boa
-      - run: conda mambabuild --channel conda-forge --channel scipp --channel mantid --no-anaconda-upload --override-channels --output-folder conda/package conda
-
-      - uses: actions/upload-artifact@v2
         with:
-          name: conda-package-ess
-          path: conda/package/*/ess*.tar.bz2
+          miniforge-version: latest
+          miniforge-variant: Mambaforge
+          environment-file: docs/environment.yml
+          activate-environment: ess-docs-build
+          auto-activate-base: false
+      - uses: actions/download-artifact@v2
+      - run: mamba install conda-package-*/*/*.tar.bz2
+      - run: python -m pytest -v tests
+      - run: python docs/make_docs.py
 
       - uses: actions/upload-artifact@v2
         with:

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -19,25 +19,27 @@ test:
     - ess.wfm
     - ess.amor
     - ess.reflectometry
-  requires:
-    # - ipympl
-    # - mantid
-    - ipywidgets
-    - pytest
-    # - pandoc
-    # - pythreejs
-    # - python-graphviz
-    # - sphinx
-    # - sphinx-book-theme<0.3
-    # - sphinx-copybutton
-    # - nbsphinx
-    # - pip
-  source_files:
-    - tests/
-    # - docs/
-  commands:
-    - python -m pytest -v tests
-    # - python docs/make_docs.py
+    - ess.sans
+    - ess.loki
+  # requires:
+  #   # - ipympl
+  #   # - mantid
+  #   - ipywidgets
+  #   - pytest
+  #   # - pandoc
+  #   # - pythreejs
+  #   # - python-graphviz
+  #   # - sphinx
+  #   # - sphinx-book-theme<0.3
+  #   # - sphinx-copybutton
+  #   # - nbsphinx
+  #   # - pip
+  # source_files:
+  #   - tests/
+  #   # - docs/
+  # commands:
+  #   - python -m pytest -v tests
+  #   # - python docs/make_docs.py
 
 build:
   number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -9,6 +9,7 @@ requirements:
   build:
     - setuptools
   run:
+    - ipywidgets
     - matplotlib
     - pooch
     - scippneutron>=0.5

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -9,6 +9,7 @@ requirements:
   build:
     - setuptools
   run:
+    - matplotlib
     - pooch
     - scippneutron>=0.5
 

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -22,32 +22,11 @@ test:
     - ess.reflectometry
     - ess.sans
     - ess.loki
-  # requires:
-  #   # - ipympl
-  #   # - mantid
-  #   - ipywidgets
-  #   - pytest
-  #   # - pandoc
-  #   # - pythreejs
-  #   # - python-graphviz
-  #   # - sphinx
-  #   # - sphinx-book-theme<0.3
-  #   # - sphinx-copybutton
-  #   # - nbsphinx
-  #   # - pip
-  # source_files:
-  #   - tests/
-  #   # - docs/
-  # commands:
-  #   - python -m pytest -v tests
-  #   # - python docs/make_docs.py
 
 build:
   number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}
   noarch: python
   script:
-    # - pip install  https://files.pythonhosted.org/packages/04/51/4b4a0740fbde50408a2f956cbb190bdc01f1c7a562627e7f102b6a30d9b4/sphinx_autodoc_typehints-1.17.0-py3-none-any.whl
-    # - pip install  https://files.pythonhosted.org/packages/9d/b4/761a6da7e1dedf793a6c3410cf362e2b61092a8fd8267d5ebc88e71f1fc5/orsopy-0.0.5-py2.py3-none-any.whl
     - pip install .
 
 about:

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -9,13 +9,9 @@ requirements:
   build:
     - setuptools
   run:
-    - astropy
-    - ipywidgets
     - matplotlib
     - pooch
     - scippneutron>=0.5
-    - scipy
-    - tifffile
 
 test:
   imports:
@@ -24,30 +20,30 @@ test:
     - ess.amor
     - ess.reflectometry
   requires:
-    - ipympl
-    - mantid
+    # - ipympl
+    # - mantid
     - pytest
-    - pandoc
-    - pythreejs
-    - python-graphviz
-    - sphinx
-    - sphinx-book-theme<0.3
-    - sphinx-copybutton
-    - nbsphinx
-    - pip
+    # - pandoc
+    # - pythreejs
+    # - python-graphviz
+    # - sphinx
+    # - sphinx-book-theme<0.3
+    # - sphinx-copybutton
+    # - nbsphinx
+    # - pip
   source_files:
     - tests/
-    - docs/
+    # - docs/
   commands:
     - python -m pytest -v tests
-    - python docs/make_docs.py
+    # - python docs/make_docs.py
 
 build:
   number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}
   noarch: python
   script:
-    - pip install  https://files.pythonhosted.org/packages/04/51/4b4a0740fbde50408a2f956cbb190bdc01f1c7a562627e7f102b6a30d9b4/sphinx_autodoc_typehints-1.17.0-py3-none-any.whl
-    - pip install  https://files.pythonhosted.org/packages/9d/b4/761a6da7e1dedf793a6c3410cf362e2b61092a8fd8267d5ebc88e71f1fc5/orsopy-0.0.5-py2.py3-none-any.whl
+    # - pip install  https://files.pythonhosted.org/packages/04/51/4b4a0740fbde50408a2f956cbb190bdc01f1c7a562627e7f102b6a30d9b4/sphinx_autodoc_typehints-1.17.0-py3-none-any.whl
+    # - pip install  https://files.pythonhosted.org/packages/9d/b4/761a6da7e1dedf793a6c3410cf362e2b61092a8fd8267d5ebc88e71f1fc5/orsopy-0.0.5-py2.py3-none-any.whl
     - pip install .
 
 about:

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -9,7 +9,6 @@ requirements:
   build:
     - setuptools
   run:
-    - matplotlib
     - pooch
     - scippneutron>=0.5
 
@@ -22,6 +21,7 @@ test:
   requires:
     # - ipympl
     # - mantid
+    - ipywidgets
     - pytest
     # - pandoc
     # - pythreejs

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -3,19 +3,22 @@ name: ess-docs-build
 channels:
   - conda-forge
   - mantid
+  - scipp
   - nodefaults
 
 dependencies:
   - ipympl
   - mantid
+  - nbsphinx
   - pandoc
+  - pooch
   - pytest
   - pythreejs
   - python-graphviz
+  - scippneutron>=0.5
   - sphinx
   - sphinx-book-theme<0.3
   - sphinx-copybutton
-  - nbsphinx
   - pip
   - pip:
     - sphinx-autodoc-typehints>=1.17.0

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -7,7 +7,7 @@ channels:
   - nodefaults
 
 dependencies:
-  - ipympl<0.9  # plots to not show up in the docs with version 0.9
+  - ipympl<0.9  # see https://github.com/matplotlib/ipympl/issues/462
   - mantid
   - nbsphinx
   - pandoc

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -7,7 +7,7 @@ channels:
   - nodefaults
 
 dependencies:
-  - ipympl<0.9
+  - ipympl<0.9  # plots to not show up in the docs with version 0.9
   - mantid
   - nbsphinx
   - pandoc
@@ -17,7 +17,7 @@ dependencies:
   - python-graphviz
   - scippneutron>=0.5
   - sphinx
-  - sphinx-book-theme<0.3
+  - sphinx-book-theme<0.3  # custom buttons in top bar do not work with version 0.3
   - sphinx-copybutton
   - pip
   - pip:

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -9,6 +9,7 @@ channels:
 dependencies:
   - ipympl
   - mantid
+  - nbconvert=6.4.5
   - nbsphinx
   - pandoc
   - pooch

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,0 +1,20 @@
+name: ess-docs-build
+
+channels:
+  - conda-forge
+  - nodefaults
+
+dependencies:
+  - ipympl
+  - mantid
+  - pandoc
+  - pythreejs
+  - python-graphviz
+  - sphinx
+  - sphinx-book-theme<0.3
+  - sphinx-copybutton
+  - nbsphinx
+  - pip
+  - pip:
+    - sphinx-autodoc-typehints>=1.17.0
+    - orsopy

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -2,6 +2,7 @@ name: ess-docs-build
 
 channels:
   - conda-forge
+  - mantid
   - nodefaults
 
 dependencies:

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -8,6 +8,7 @@ dependencies:
   - ipympl
   - mantid
   - pandoc
+  - pytest
   - pythreejs
   - python-graphviz
   - sphinx

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -7,9 +7,8 @@ channels:
   - nodefaults
 
 dependencies:
-  - ipympl
+  - ipympl<0.9
   - mantid
-  - nbconvert=6.4.5
   - nbsphinx
   - pandoc
   - pooch

--- a/tests/reflectometry/corrections_test.py
+++ b/tests/reflectometry/corrections_test.py
@@ -74,3 +74,4 @@ def test_beam_on_sample_array():
                                values=[10.01668613, 2.085829643],
                                unit=sc.units.mm)
     assert sc.allclose(expected_result, corrections.beam_on_sample(beam_size, theta))
+    assert False

--- a/tests/reflectometry/corrections_test.py
+++ b/tests/reflectometry/corrections_test.py
@@ -74,4 +74,3 @@ def test_beam_on_sample_array():
                                values=[10.01668613, 2.085829643],
                                unit=sc.units.mm)
     assert sc.allclose(expected_result, corrections.beam_on_sample(beam_size, theta))
-    assert False


### PR DESCRIPTION
Having docs building as part of the conda-build tests is not good when `pip` packages are required because those packages end up in the conda package.

We build the docs in a separate step, as is done in scipp, to avoid this.