### PR TITLE
Remove cap on scippneutron version pinning and prepare release 0.7.1

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -15,7 +15,7 @@ requirements:
     - ipywidgets
     - matplotlib
     - pooch
-    - scippneutron=0.7.*
+    - scippneutron>=0.7
 
 test:
   imports:

--- a/docs/_templates/topbar/launchbuttons.html
+++ b/docs/_templates/topbar/launchbuttons.html
@@ -12,7 +12,7 @@
             href="https://scipp.github.io/ess"><button type="button"
                 class="btn btn-secondary topbarbtn">latest</button></a>
         <a class="dropdown-buttons"
-            href="https://scipp.github.io/ess/release/0.7.0"><button type="button"
+            href="https://scipp.github.io/ess/release/0.7.1"><button type="button"
                 class="btn btn-secondary topbarbtn">v0.7</button></a>
         <a class="dropdown-buttons"
             href="https://scipp.github.io/ess/release/0.6.0"><button type="button"

--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -3,6 +3,23 @@
 Release Notes
 =============
 
+v0.7.1 (June 2022)
+------------------
+
+See full changelog `here <https://github.com/scipp/ess/releases/tag/0.7.1>`_.
+
+Features
+~~~~~~~~
+
+* Removed cap on version pinning for ``scippneutron`` `#130 <https://github.com/scipp/ess/pull/130>`_.
+
+Contributors
+~~~~~~~~~~~~
+
+Simon Heybrock :sup:`a`\ ,
+Neil Vaytet :sup:`a`\ ,
+and Jan-Lukas Wynen :sup:`a`
+
 v0.7.0 (June 2022)
 ------------------
 

--- a/docs/about/release-notes.rst
+++ b/docs/about/release-notes.rst
@@ -11,7 +11,7 @@ See full changelog `here <https://github.com/scipp/ess/releases/tag/0.7.1>`_.
 Features
 ~~~~~~~~
 
-* Removed cap on version pinning for ``scippneutron`` `#130 <https://github.com/scipp/ess/pull/130>`_.
+* Removed cap on version pinning for ``scippneutron`` `#132 <https://github.com/scipp/ess/pull/132>`_.
 
 Contributors
 ~~~~~~~~~~~~

--- a/environment.yml
+++ b/environment.yml
@@ -20,7 +20,7 @@ dependencies:
   - pytest
   - pythreejs
   - python-graphviz
-  - scippneutron=0.7.*
+  - scippneutron>=0.7
   - sphinx
   - sphinx-book-theme=0.2  # custom buttons in top bar do not work with version 0.3
   - sphinx-copybutton


### PR DESCRIPTION
For some background about why we are removing the upper limit on the version number, see https://iscinumpy.dev/post/bound-version-constraints/