### PR TITLE
Configure Mantid's logger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,11 @@ src/ess/_version.py
 .virtual_documents
 __pycache__
 
+# Data
+*.h5
+*.hdf5
+*.nxs
+*.ort
+
 # Misc
 *.log

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ src/ess/_version.py
 .mypy_cache
 .virtual_documents
 __pycache__
+
+# Misc
+*.log

--- a/docs/instruments/loki/sans2d_reduction.ipynb
+++ b/docs/instruments/loki/sans2d_reduction.ipynb
@@ -47,7 +47,7 @@
    },
    "outputs": [],
    "source": [
-    "_ = configure_workflow('sans2d_reduction', filename='sans2d.log')"
+    "logger = configure_workflow('sans2d_reduction', filename='sans2d.log')"
    ]
   },
   {

--- a/docs/instruments/loki/sans2d_reduction.ipynb
+++ b/docs/instruments/loki/sans2d_reduction.ipynb
@@ -26,13 +26,28 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "8c7f7cf7-0582-4953-a772-a0f87d1cf0e2",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "import matplotlib.pyplot as plt\n",
     "import scipp as sc\n",
     "from ess import loki, sans\n",
+    "from ess.logging import configure_workflow\n",
     "import scippneutron as scn"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f55b66b3-d206-45a5-be17-bd51893f654b",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "_ = configure_workflow('sans2d_reduction', filename='sans2d.log')"
    ]
   },
   {
@@ -481,7 +496,8 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3"
+   "pygments_lexer": "ipython3",
+   "version": "3.8.12"
   }
  },
  "nbformat": 4,

--- a/docs/instruments/loki/sans2d_reduction.ipynb
+++ b/docs/instruments/loki/sans2d_reduction.ipynb
@@ -496,8 +496,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/docs/instruments/loki/sans2d_to_I_of_Q.ipynb
+++ b/docs/instruments/loki/sans2d_to_I_of_Q.ipynb
@@ -60,7 +60,7 @@
    },
    "outputs": [],
    "source": [
-    "_ = configure_workflow('sans2d_I_of_Q', filename='sans2d.log')"
+    "logger = configure_workflow('sans2d_I_of_Q', filename='sans2d.log')"
    ]
   },
   {

--- a/docs/instruments/loki/sans2d_to_I_of_Q.ipynb
+++ b/docs/instruments/loki/sans2d_to_I_of_Q.ipynb
@@ -32,12 +32,35 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "8c7f7cf7-0582-4953-a772-a0f87d1cf0e2",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "import scipp as sc\n",
     "from ess import loki, sans\n",
+    "from ess.logging import configure_workflow\n",
     "import scippneutron as scn"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "42f0d79d-0147-4928-bd45-c0932a33fae1",
+   "metadata": {},
+   "source": [
+    "Set up the logging systems of scipp (including scippneutron and ess) and Mantid."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "760adfde-01e6-4d25-bc8d-b8bbd20c0467",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "_ = configure_workflow('sans2d_I_of_Q', filename='sans2d.log')"
    ]
   },
   {
@@ -746,7 +769,8 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3"
+   "pygments_lexer": "ipython3",
+   "version": "3.8.12"
   }
  },
  "nbformat": 4,

--- a/docs/instruments/loki/sans2d_to_I_of_Q.ipynb
+++ b/docs/instruments/loki/sans2d_to_I_of_Q.ipynb
@@ -769,8 +769,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/src/ess/logging.py
+++ b/src/ess/logging.py
@@ -29,13 +29,20 @@ import scippneutron as scn
 
 
 def get_logger(subname: Optional[str] = None) -> logging.Logger:
-    """
-    Return one of ess's loggers.
+    """Return one of ess's loggers.
 
-    :param subname: Name of an instrument, technique, or workflow.
-                    If given, return the logger with the given name
-                    as a child of the ess logger.
-                    Otherwise, return the general ess logger.
+    Parameters
+    ----------
+    subname:
+        Name of an instrument, technique, or workflow.
+        If given, return the logger with the given name
+        as a child of the ess logger.
+        Otherwise, return the general ess logger.
+
+    Returns
+    -------
+    :
+        The requested logger.
     """
     name = 'scipp.ess' + ('.' + subname if subname else '')
     return logging.getLogger(name)
@@ -137,18 +144,31 @@ def configure(*,
       - *Widget Handler* Writes to a :py:class:`scipp.logging.LogWidget`
         if Python is running in a Jupyter notebook.
 
-    :param filename: Name of the log file.
-                     Overwrites existing files.
-                     Setting this to `None` disables logging to file.
-    :param file_level: Log level for the file handler.
-    :param stream_level: Log level for the stream handler.
-    :param widget_level: Log level for the widget handler.
-    :param show_thread: If `True`, log messages include the name of the thread
-                        the message originates from.
-    :param show_process: If `True`, log messages include the name of the process
-                         the message originates from.
-    :param loggers: Collection of loggers or names of loggers to configure.
-                    If not given, uses :py:func:`default_loggers_to_configure`.
+    Parameters
+    ----------
+    filename:
+        Name of the log file. Overwrites existing files.
+        Setting this to `None` disables logging to file.
+    file_level:
+        Log level for the file handler.
+    stream_level:
+        Log level for the stream handler.
+    widget_level:
+        Log level for the widget handler.
+    show_thread:
+        If `True`, log messages include the name of the thread
+        the message originates from.
+    show_process:
+        If `True`, log messages include the name of the process
+        the message originates from.
+    loggers:
+        Collection of loggers or names of loggers to configure.
+        If not given, uses :py:func:`default_loggers_to_configure`.
+
+    See Also
+    --------
+    ess.logging.configure_workflow:
+        Configure logging and do some additional setup for a reduction workflow.
     """
     if configure.is_configured:
         get_logger().warning(
@@ -176,16 +196,32 @@ def configure_workflow(workflow_name: Optional[str] = None,
                        *,
                        display: Optional[bool] = None,
                        **kwargs) -> logging.Logger:
-    """
-    Configure logging for a reduction workflow.
+    """Configure logging for a reduction workflow.
 
-    :param workflow_name: Used as the name of the returned logger.
-    :param display: If `True`, show a :py:class:`scipp.logging.LogWidget`
-                    in the outputs of the current cell.
-                    Defaults to `True` in Jupyter and `False` otherwise.
-    :param kwargs: Forwarded to :py:func:`ess.logging.configure`.
-                   Refer to that function for details.
-    :return: A logger for use in the workflow.
+    Configures loggers, logs a greeting message, sets up a logger for a workflow,
+    and optionally creates and displays a log widget.
+
+    Parameters
+    ----------
+    workflow_name:
+        Used as the name of the returned logger.
+    display:
+        If `True`, show a :py:class:`scipp.logging.LogWidget`
+        in the outputs of the current cell.
+        Defaults to `True` in Jupyter and `False` otherwise.
+    kwargs:
+        Forwarded to :py:func:`ess.logging.configure`.
+        Refer to that function for details.
+
+    Returns
+    -------
+    :
+        A logger for use in the workflow.
+
+    See Also
+    --------
+    ess.logging.configure:
+        General logging setup.
     """
     configure(**kwargs)
     greet()

--- a/src/ess/logging.py
+++ b/src/ess/logging.py
@@ -184,7 +184,8 @@ def configure(*,
     }
     for logger in loggers:
         _configure_logger(logger, handlers, base_level)
-    # TODO mantid's own config
+    if any(logger.name == 'Mantid' for logger in loggers):
+        _configure_mantid_logging('notice')
 
     configure.is_configured = True
 
@@ -304,6 +305,14 @@ def _configure_logger(logger: logging.Logger, handlers: List[logging.Handler],
     for handler in handlers:
         logger.addHandler(handler)
     logger.setLevel(level)
+
+
+def _configure_mantid_logging(level: str):
+    try:
+        from mantid.utils.logging import log_to_python
+        log_to_python(level)
+    except ImportError:
+        pass
 
 
 def _base_level(levels: List[Union[str, int]]) -> int:


### PR DESCRIPTION
With Mantid 6.4, we can now capture Mantid's log messages and display them along our logs. This should fix the problem of messages not showing sometimes.

If an older version of Mantid is installed, the configuration will work as before and not touch Mantid.