### PR TITLE
Updating the amor documentation plotting to use plopp

### DIFF
--- a/.buildconfig/ci.yml
+++ b/.buildconfig/ci.yml
@@ -315,3 +315,4 @@ dependencies:
     - nb-clean==2.3.0
     - orsopy==1.0.1
     - sphinx-autodoc-typehints==1.18.3
+    - plopp=0.3.3

--- a/.buildconfig/ci.yml
+++ b/.buildconfig/ci.yml
@@ -315,4 +315,4 @@ dependencies:
     - nb-clean==2.3.0
     - orsopy==1.0.1
     - sphinx-autodoc-typehints==1.18.3
-    - plopp=0.3.3
+    - plopp==0.3.3

--- a/.buildconfig/ci.yml
+++ b/.buildconfig/ci.yml
@@ -220,6 +220,7 @@ dependencies:
   - pip=22.2.2
   - pixman=0.40.0
   - pkgutil-resolve-name=1.3.10
+  - plopp=0.3.4
   - pluggy=1.0.0
   - poco=1.11.1
   - pooch=1.6.0
@@ -315,4 +316,3 @@ dependencies:
     - nb-clean==2.3.0
     - orsopy==1.0.1
     - sphinx-autodoc-typehints==1.18.3
-    - plopp==0.3.3

--- a/docs/instruments/amor/amor_reduction.ipynb
+++ b/docs/instruments/amor/amor_reduction.ipynb
@@ -807,8 +807,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/docs/instruments/amor/amor_reduction.ipynb
+++ b/docs/instruments/amor/amor_reduction.ipynb
@@ -22,8 +22,10 @@
    "outputs": [],
    "source": [
     "import scipp as sc\n",
+    "import plopp as pp\n",
     "from ess import amor, reflectometry\n",
-    "import ess"
+    "import ess\n",
+    "pp.patch_scipp()"
    ]
   },
   {
@@ -164,7 +166,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sc.plot(sample)"
+    "sample.hist(tof=40).plot()"
    ]
   },
   {
@@ -203,24 +205,6 @@
     "reference.coords['position'].fields.y += pixel_position_correction(reference)\n",
     "sample.attrs['orso'].value.data_source.measurement.comment = 'Pixel positions corrected'\n",
     "reference.attrs['orso'].value.data_source.measurement.comment = 'Pixel positions corrected'"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "5746a0e8-6e90-459b-a8cf-37af826686f9",
-   "metadata": {},
-   "source": [
-    "We now check that the detector pixels are in the correct position by showing the instrument view"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "77c70704-b45f-4131-aa84-63765a99668a",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "amor.instrument_view(sample)"
    ]
   },
   {
@@ -315,11 +299,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c7e4ecca-bb23-4b6c-a056-ebb9dcfa579d",
+   "id": "ba03ff0f-0377-4e4f-8a0f-3f4c987c002c",
    "metadata": {},
    "outputs": [],
    "source": [
-    "sample_wav.bins.concatenate('detector_id').plot()"
+    "sample_wav.bins.concat('detector_id').hist(wavelength=200).plot()"
    ]
   },
   {
@@ -499,7 +483,7 @@
     "reference_q = reflectometry.conversions.theta_to_q(\n",
     "    reference_theta, q_edges=q_edges, graph=graph)\n",
     "\n",
-    "sc.plot({'sample': sample_q.sum('detector_id'),\n",
+    "pp.plot({'sample': sample_q.sum('detector_id'),\n",
     "         'uncalibrated reference': reference_q.sum('detector_id')},\n",
     "        norm=\"log\")"
    ]
@@ -555,7 +539,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sc.plot({'Uncalibrated': reference_q_summed.sum('detector_id'), \n",
+    "pp.plot({'Uncalibrated': reference_q_summed.sum('detector_id'), \n",
     "         'Calibrated': reference_q_summed_cal.sum('detector_id')}, \n",
     "        norm='log')"
    ]
@@ -614,11 +598,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7b26b666-4a61-4e9e-b361-9089e62658f6",
+   "id": "03b65d9c-1d50-4fae-ae62-046ea1aeda83",
    "metadata": {},
    "outputs": [],
    "source": [
-    "sc.plot(normalized, resolution={'y': 1000, 'x': 201}, norm='log')"
+    "normalized.plot(norm='log')"
    ]
   },
   {
@@ -638,7 +622,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sc.plot(normalized.mean('detector_id'), norm='log')"
+    "normalized.mean('detector_id').plot(norm='log')"
    ]
   },
   {
@@ -742,7 +726,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sample_theta = sample_theta.bins.concatenate('detector_id')"
+    "sample_theta = sample_theta.bins.concat('detector_id')"
    ]
   },
   {
@@ -823,7 +807,8 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3"
+   "pygments_lexer": "ipython3",
+   "version": "3.9.13"
   }
  },
  "nbformat": 4,

--- a/environment.yml
+++ b/environment.yml
@@ -27,5 +27,6 @@ dependencies:
   - yapf
   - pip:
     - nb-clean
+    - plopp
     - sphinx-autodoc-typehints==1.18.3
     - orsopy

--- a/environment.yml
+++ b/environment.yml
@@ -17,6 +17,7 @@ dependencies:
   - pandoc
   - pip
   - pooch
+  - plopp
   - pytest
   - pythreejs
   - python-graphviz
@@ -27,6 +28,5 @@ dependencies:
   - yapf
   - pip:
     - nb-clean
-    - plopp
     - sphinx-autodoc-typehints==1.18.3
     - orsopy


### PR DESCRIPTION
As in the title. Note that I have removed the instrument view. I plan to replace this with a plot of the logical x- and y-dimensions summed along z once https://github.com/scipp/ess/pull/139 is merged. 