### PR TITLE
fixing gravity variable in denominator

### DIFF
--- a/docs/instruments/loki/sans2d_to_I_of_Q.ipynb
+++ b/docs/instruments/loki/sans2d_to_I_of_Q.ipynb
@@ -671,7 +671,7 @@
     "    graph=data_graph,\n",
     "    wavelength_bands=wavelength_bands,\n",
     "    q_bins=q_bins,\n",
-    "    gravity=True)\n",
+    "    gravity=gravity)\n",
     "\n",
     "sc.plot(denominator_q, norm='log')"
    ]
@@ -769,7 +769,8 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3"
+   "pygments_lexer": "ipython3",
+   "version": "3.8.12"
   }
  },
  "nbformat": 4,

--- a/docs/instruments/loki/sans2d_to_I_of_Q.ipynb
+++ b/docs/instruments/loki/sans2d_to_I_of_Q.ipynb
@@ -769,8 +769,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This is a one-liner setting `gravity` variable in the denominator based on the earlier defined variable rather than a fixed value. It was throwing an error when `gravity` at the begining of the notebook was set to False (mismatched with True value in the denominator). 