### PR TITLE
Disable pypi upload because the name `ess` is not authorized

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -50,7 +50,7 @@ jobs:
 
       - run: conda develop src
       - run: jupyter --paths
-      - run: python docs/make_docs.py --build_dir=html
+      - run: python docs/make_docs.py --build-dir=html
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/pr_and_main.yml
+++ b/.github/workflows/pr_and_main.yml
@@ -63,7 +63,7 @@ jobs:
       - run: conda develop src
       - run: jupyter --paths
       - run: python -m pytest -v tests
-      - run: python docs/make_docs.py --build_dir=docs_html_${{ matrix.os }}
+      - run: python docs/make_docs.py --build-dir=docs_html_${{ matrix.os }}
 
       - uses: actions/upload-artifact@v3
         if: ${{ contains(matrix.os, 'ubuntu') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,10 +78,11 @@ jobs:
       - run: anaconda --token ${{ secrets.ANACONDATOKEN }} upload --user scipp --label main $(ls conda-package-*/*/*.tar.bz2)
       - uses: actions/setup-python@v3
 
-      - uses: pypa/gh-action-pypi-publish@v1.6.4
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_TOKEN }}
+      # We disable pypi upload for now, because the name `ess` is not authorised
+      # - uses: pypa/gh-action-pypi-publish@v1.6.4
+      #   with:
+      #     user: __token__
+      #     password: ${{ secrets.PYPI_TOKEN }}
 
   manage-versions:
     name: Manage Versions

--- a/docs/make_docs.py
+++ b/docs/make_docs.py
@@ -8,28 +8,30 @@ import subprocess
 import sys
 
 parser = argparse.ArgumentParser(description='Build doc pages with sphinx')
-parser.add_argument('--build-dir', default='build')
-parser.add_argument('--work-dir', default='.doctrees')
+parser.add_argument('--build-dir', default=None)
+parser.add_argument('--work-dir', default=None)
 parser.add_argument('--builder', default='html')
 
 if __name__ == '__main__':
     args = parser.parse_args()
 
     docs_dir = pathlib.Path(__file__).parent.absolute()
+    work_dir = args.work_dir if args.work_dir is not None else os.path.join(
+        docs_dir, '.doctrees')
+    build_dir = args.build_dir if args.build_dir is not None else os.path.join(
+        docs_dir, 'build')
 
     # Build the docs with sphinx-build
-    subprocess.check_call([
-        'sphinx-build', '-v', '-b', args.builder, '-d', args.work_dir, docs_dir,
-        args.build_dir
-    ],
-                          stderr=subprocess.STDOUT,
-                          shell=sys.platform == "win32")
+    subprocess.check_call(
+        ['sphinx-build', '-v', '-b', args.builder, '-d', work_dir, docs_dir, build_dir],
+        stderr=subprocess.STDOUT,
+        shell=sys.platform == "win32")
 
     # Remove Jupyter notebooks used for documentation build,
     # they are not accessible and create size bloat.
     # However, keep the ones in the `_sources` folder,
     # as the download buttons links to them.
-    sources_dir = os.path.join(args.build_dir, '_sources')
-    for path in pathlib.Path(args.build_dir).rglob('*.ipynb'):
+    sources_dir = os.path.join(build_dir, '_sources')
+    for path in pathlib.Path(build_dir).rglob('*.ipynb'):
         if not str(path).startswith(sources_dir):
             os.remove(path)

--- a/docs/make_docs.py
+++ b/docs/make_docs.py
@@ -8,8 +8,8 @@ import subprocess
 import sys
 
 parser = argparse.ArgumentParser(description='Build doc pages with sphinx')
-parser.add_argument('--build_dir', default='build')
-parser.add_argument('--work_dir', default='.doctrees')
+parser.add_argument('--build-dir', default='build')
+parser.add_argument('--work-dir', default='.doctrees')
 parser.add_argument('--builder', default='html')
 
 
@@ -23,9 +23,10 @@ def get_abs_path(path, root):
 if __name__ == '__main__':
     args = parser.parse_args()
 
+    cwd = os.getcwd()
     docs_dir = pathlib.Path(__file__).parent.absolute()
-    work_dir = get_abs_path(path=args.work_dir, root=docs_dir)
-    build_dir = get_abs_path(path=args.build_dir, root=docs_dir)
+    work_dir = os.path.join(cwd, get_abs_path(path=args.work_dir, root=docs_dir))
+    build_dir = os.path.join(cwd, get_abs_path(path=args.build_dir, root=docs_dir))
     if not os.path.exists(build_dir):
         os.makedirs(build_dir)
 

--- a/docs/make_docs.py
+++ b/docs/make_docs.py
@@ -12,35 +12,24 @@ parser.add_argument('--build-dir', default='build')
 parser.add_argument('--work-dir', default='.doctrees')
 parser.add_argument('--builder', default='html')
 
-
-def get_abs_path(path, root):
-    if os.path.isabs(path):
-        return path
-    else:
-        return os.path.join(root, path)
-
-
 if __name__ == '__main__':
     args = parser.parse_args()
 
-    cwd = os.getcwd()
     docs_dir = pathlib.Path(__file__).parent.absolute()
-    work_dir = os.path.join(cwd, get_abs_path(path=args.work_dir, root=docs_dir))
-    build_dir = os.path.join(cwd, get_abs_path(path=args.build_dir, root=docs_dir))
-    if not os.path.exists(build_dir):
-        os.makedirs(build_dir)
 
     # Build the docs with sphinx-build
-    subprocess.check_call(
-        ['sphinx-build', '-v', '-b', args.builder, '-d', work_dir, docs_dir, build_dir],
-        stderr=subprocess.STDOUT,
-        shell=sys.platform == "win32")
+    subprocess.check_call([
+        'sphinx-build', '-v', '-b', args.builder, '-d', args.work_dir, docs_dir,
+        args.build_dir
+    ],
+                          stderr=subprocess.STDOUT,
+                          shell=sys.platform == "win32")
 
     # Remove Jupyter notebooks used for documentation build,
     # they are not accessible and create size bloat.
     # However, keep the ones in the `_sources` folder,
     # as the download buttons links to them.
-    sources_dir = os.path.join(build_dir, '_sources')
-    for path in pathlib.Path(build_dir).rglob('*.ipynb'):
+    sources_dir = os.path.join(args.build_dir, '_sources')
+    for path in pathlib.Path(args.build_dir).rglob('*.ipynb'):
         if not str(path).startswith(sources_dir):
             os.remove(path)


### PR DESCRIPTION
Disabling for now, until we figure out what to do next.