### PR TITLE
Drop monitor variances in SANS

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
         args: [ --markdown-linebreak-ext=md ]
         exclude: '\.svg'
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         name: isort (python)

--- a/docs/instruments/loki/sans2d_to_I_of_Q.ipynb
+++ b/docs/instruments/loki/sans2d_to_I_of_Q.ipynb
@@ -148,6 +148,31 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ef04d51b-f6de-406b-85f6-f944ebc5f0c4",
+   "metadata": {},
+   "source": [
+    "Monitors will be broadcast to all pixels of the detectors and this introduces correlations if the monitors have variances.\n",
+    "So simply remove variances from the monitors.\n",
+    "This is only correct as long as the monitors have many more counts than the detectors."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "323d8ecc-82ff-43bd-989a-ad201d624e3d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "monitors = {\n",
+    "    'sample': sans.i_of_q.drop_monitor_variances(\n",
+    "        monitors['sample'], data=sample),\n",
+    "    'direct': sans.i_of_q.drop_monitor_variances(\n",
+    "        monitors['direct'], data=direct),\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "e3b0b991-85c4-40fe-a903-74b43716a155",
    "metadata": {},
    "source": [
@@ -769,7 +794,8 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3"
+   "pygments_lexer": "ipython3",
+   "version": "3.8.12"
   }
  },
  "nbformat": 4,

--- a/docs/utilities/utilities.rst
+++ b/docs/utilities/utilities.rst
@@ -10,3 +10,4 @@ Modules
 
    logging
    nexus
+   uncertainty

--- a/src/ess/sans/i_of_q.py
+++ b/src/ess/sans/i_of_q.py
@@ -1,13 +1,14 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 
-from typing import Tuple, Union
+from typing import Tuple, Union,Dict
 
 import scipp as sc
 from scipp.scipy.interpolate import interp1d
 
 from . import conversions, normalization
 from .common import gravity_vector
+from ..uncertainty import drop_variances
 
 
 def make_coordinate_transform_graphs(gravity: bool) -> Tuple[dict, dict]:
@@ -188,6 +189,35 @@ def _make_dict_of_monitors(data_monitors, direct_monitors):
     return {'data': data_monitors, 'direct': direct_monitors}
 
 
+def drop_monitor_variances(monitors: Dict[str, sc.DataArray], *, data: sc.DataArray) -> Dict[str, sc.DataArray]:
+    """
+    Return monitors without variances.
+
+    This is only valid if the monitors have significantly more counts
+    than the detector data.
+
+    Parameters
+    ----------
+    monitors:
+        Dict of monitors.
+    data:
+        Detector data the monitors correspond to.
+
+    Returns
+    -------
+    :
+        ``monitors`` without variances.
+
+    See Also
+    --------
+    ess.uncertainty.drop_monitor_variances:
+        Generic function for dropping variances.
+    """
+    return {name: drop_variances(monitor, reference=data, name=name+' monitor')
+            for name, monitor in monitors.items()}
+
+
+
 def to_I_of_Q(data: sc.DataArray,
               data_monitors: dict,
               direct_monitors: dict,
@@ -239,8 +269,8 @@ def to_I_of_Q(data: sc.DataArray,
         that contribute to different regions in Q space.
     """
 
-    monitors = _make_dict_of_monitors(data_monitors=data_monitors,
-                                      direct_monitors=direct_monitors)
+    monitors = _make_dict_of_monitors(data_monitors=drop_monitor_variances(data_monitors, data=data),
+                                      direct_monitors=drop_monitor_variances(direct_monitors, data=direct_beam))
 
     data_graph, monitor_graph = make_coordinate_transform_graphs(gravity=gravity)
 

--- a/src/ess/sans/i_of_q.py
+++ b/src/ess/sans/i_of_q.py
@@ -1,14 +1,14 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 
-from typing import Tuple, Union,Dict
+from typing import Dict, Tuple, Union
 
 import scipp as sc
 from scipp.scipy.interpolate import interp1d
 
+from ..uncertainty import drop_variances
 from . import conversions, normalization
 from .common import gravity_vector
-from ..uncertainty import drop_variances
 
 
 def make_coordinate_transform_graphs(gravity: bool) -> Tuple[dict, dict]:
@@ -189,7 +189,8 @@ def _make_dict_of_monitors(data_monitors, direct_monitors):
     return {'data': data_monitors, 'direct': direct_monitors}
 
 
-def drop_monitor_variances(monitors: Dict[str, sc.DataArray], *, data: sc.DataArray) -> Dict[str, sc.DataArray]:
+def drop_monitor_variances(monitors: Dict[str, sc.DataArray], *,
+                           data: sc.DataArray) -> Dict[str, sc.DataArray]:
     """
     Return monitors without variances.
 
@@ -213,9 +214,10 @@ def drop_monitor_variances(monitors: Dict[str, sc.DataArray], *, data: sc.DataAr
     ess.uncertainty.drop_monitor_variances:
         Generic function for dropping variances.
     """
-    return {name: drop_variances(monitor, reference=data, name=name+' monitor')
-            for name, monitor in monitors.items()}
-
+    return {
+        name: drop_variances(monitor, reference=data, name=name + ' monitor')
+        for name, monitor in monitors.items()
+    }
 
 
 def to_I_of_Q(data: sc.DataArray,
@@ -269,8 +271,9 @@ def to_I_of_Q(data: sc.DataArray,
         that contribute to different regions in Q space.
     """
 
-    monitors = _make_dict_of_monitors(data_monitors=drop_monitor_variances(data_monitors, data=data),
-                                      direct_monitors=drop_monitor_variances(direct_monitors, data=direct_beam))
+    monitors = _make_dict_of_monitors(
+        data_monitors=drop_monitor_variances(data_monitors, data=data),
+        direct_monitors=drop_monitor_variances(direct_monitors, data=direct_beam))
 
     data_graph, monitor_graph = make_coordinate_transform_graphs(gravity=gravity)
 

--- a/src/ess/uncertainty.py
+++ b/src/ess/uncertainty.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
+"""Tools for handling statistical uncertainties."""
+
+import scipp as sc
+from typing import Union, TypeVar
+from .logging import get_logger
+
+
+T = TypeVar("T", bound=Union[sc.Variable, sc.DataArray])
+
+def drop_variances(da: T, *, reference: Union[sc.Variable, sc.DataArray], name: str='', threshold: float=1.0) -> T:
+    # TODO cite our paper
+    """Return the input values without variances.
+
+    This assumes that ``da`` will be used as a normalization
+    factor for ``reference``. That is, downstream code will perform an operation
+    along the lines of ``reference / da``. It furthermore assumes that ``da``
+    needs to be broadcast to the shape of ``reference`` in that operation.
+    This broadcast would be forbidden with variances in Scipp, hence the need
+    to drop them.
+
+    A message will be logged showing :math:`\\alpha`, the ratio
+    ``reference.sum() / da.sum()``, which indicates whether dropping variances
+    might lead to underestimated uncertainties in the final result.
+
+    Parameters
+    ----------
+    da:
+        Data to remove variances from.
+    reference:
+        Assume that ``da`` will be used to normalize ``reference``.
+    name:
+        Optional name for ``da``. Shown in log messages.
+    threshold:
+        Log a warning if :math:`\\alpha` is above this value,
+        log on 'info' level otherwise.
+
+    Returns
+    -------
+    :
+        ``sc.values(da)``
+    """
+    alpha = _compute_alpha(numerator=reference, denominator=da)
+    logger = get_logger()
+    msg = 'Dropping variances%s. Total counts divided by reference: alpha = %f'
+    if alpha < threshold:
+        logger.info(msg, f" of '{name}'" if name else '', alpha)
+    else:
+        logger.warning(msg + ' This value may be too large and the uncertainties of the result may be underestimated.',
+                       f"of '{name}'" if name else '', alpha)
+    return sc.values(da)
+
+
+def _compute_alpha(numerator: Union[sc.Variable, sc.DataArray], denominator: Union[sc.Variable, sc.DataArray]) -> float:
+    alpha = numerator.sum().data / denominator.sum().data
+    if alpha.unit != 'one':
+        raise sc.UnitError('Cannot compare counts, the reference has a different unit from the data.')
+    return float(alpha.value)

--- a/src/ess/uncertainty.py
+++ b/src/ess/uncertainty.py
@@ -2,14 +2,20 @@
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 """Tools for handling statistical uncertainties."""
 
-import scipp as sc
-from typing import Union, TypeVar
-from .logging import get_logger
+from typing import TypeVar, Union
 
+import scipp as sc
+
+from .logging import get_logger
 
 T = TypeVar("T", bound=Union[sc.Variable, sc.DataArray])
 
-def drop_variances(da: T, *, reference: Union[sc.Variable, sc.DataArray], name: str='', threshold: float=1.0) -> T:
+
+def drop_variances(da: T,
+                   *,
+                   reference: Union[sc.Variable, sc.DataArray],
+                   name: str = '',
+                   threshold: float = 1.0) -> T:
     # TODO cite our paper
     """Return the input values without variances.
 
@@ -47,13 +53,16 @@ def drop_variances(da: T, *, reference: Union[sc.Variable, sc.DataArray], name: 
     if alpha < threshold:
         logger.info(msg, f" of '{name}'" if name else '', alpha)
     else:
-        logger.warning(msg + ' This value may be too large and the uncertainties of the result may be underestimated.',
-                       f"of '{name}'" if name else '', alpha)
+        logger.warning(
+            msg + ' This value may be too large and the uncertainties of the result '
+            'may be underestimated.', f"of '{name}'" if name else '', alpha)
     return sc.values(da)
 
 
-def _compute_alpha(numerator: Union[sc.Variable, sc.DataArray], denominator: Union[sc.Variable, sc.DataArray]) -> float:
+def _compute_alpha(numerator: Union[sc.Variable, sc.DataArray],
+                   denominator: Union[sc.Variable, sc.DataArray]) -> float:
     alpha = numerator.sum().data / denominator.sum().data
     if alpha.unit != 'one':
-        raise sc.UnitError('Cannot compare counts, the reference has a different unit from the data.')
+        raise sc.UnitError(
+            'Cannot compare counts, the reference has a different unit from the data.')
     return float(alpha.value)


### PR DESCRIPTION
Fixes #162

I chose the threshold quite arbitrarily by looking at Fig 2 in out paper. Is it reasonable?

Compared to the issue, this will always go through, no matter the value of alpha. Does this make sense or should it better raise an exception if alpha is too large? What is too large?

Interestingly, there one figure changed in this, the plot in cell 25 of 'SANS2D: I(Q) workflow for a single run (sample)' is as shown below. It has visible error bars for high Q while the old plot does not. Hope this is a good sign...
![Figure 2](https://user-images.githubusercontent.com/11393224/220382590-c355cae5-06e6-47df-be15-09d16290d0b5.png)
