### PR TITLE
Save detector masks

### DIFF
--- a/docs/utilities/utilities.rst
+++ b/docs/utilities/utilities.rst
@@ -9,5 +9,6 @@ Modules
    :recursive:
 
    logging
+   masking
    nexus
    uncertainty

--- a/src/ess/masking.py
+++ b/src/ess/masking.py
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 from pathlib import Path
-from typing import Union, Mapping, Optional
+from typing import Mapping, Optional, Union
+
 import h5py
 import scipp as sc
 

--- a/src/ess/masking.py
+++ b/src/ess/masking.py
@@ -1,14 +1,16 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 from pathlib import Path
-from typing import Mapping, Union
-
+from typing import Union, Mapping, Optional
 import h5py
 import scipp as sc
 
 
 def save_detector_masks(
-    filename: Union[str, Path], detectors: Mapping[str, sc.DataArray]
+    filename: Union[str, Path],
+    detectors: Mapping[str, sc.DataArray],
+    *,
+    entry_metadata: Optional[Mapping[str, Union[str, int]]] = None,
 ) -> None:
     """
     Save detector masks to an HDF5/NeXus file.
@@ -22,10 +24,16 @@ def save_detector_masks(
         Name of the file to save to.
     detectors:
         Dictionary of data arrays whose masks should be saved.
+    entry_metadata:
+        Optional dictionary of metadata to save in the NXentry group. Typically this
+        should contain 'experiment_identifier', 'start_time', and 'end_time'.
     """
     with h5py.File(filename, "w-") as f:
         entry = f.require_group("entry")
         entry.attrs["NX_class"] = "NXentry"
+        if entry_metadata:
+            for key, value in entry_metadata.items():
+                entry[key] = value
         instrument = entry.require_group("instrument")
         instrument.attrs["NX_class"] = "NXinstrument"
         for name, det in detectors.items():

--- a/src/ess/masking.py
+++ b/src/ess/masking.py
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 from pathlib import Path
-from typing import Union, Mapping
+from typing import Mapping, Union
+
 import h5py
 import scipp as sc
 

--- a/src/ess/masking.py
+++ b/src/ess/masking.py
@@ -28,6 +28,37 @@ def save_detector_masks(
     entry_metadata:
         Optional dictionary of metadata to save in the NXentry group. Typically this
         should contain 'experiment_identifier', 'start_time', and 'end_time'.
+
+    Examples
+    --------
+
+    Consider a data group with two detectors, one with a mask and one without, as well
+    as some metadata:
+
+      >>> import scipp as sc
+      >>>
+      >>> dg = sc.DataGroup()
+      >>> dg['mantle_detector'] = sc.DataArray(
+      ...     data=sc.ones(dims=['tube', 'pixel'], shape=[3, 100]),
+      ...     masks={'bad_tube': sc.array(dims=['tube'], values=[False, True, False])},
+      ... )
+      >>> dg['endcap_detector'] = sc.DataArray(
+      ...     data=sc.ones(dims=['x', 'y'], shape=[2, 2]), masks={}
+      ... )
+      >>> metadata = {'experiment_identifier': 12345}
+
+    Save the masks to a file:
+
+      >>> from ess.masking import save_detector_masks
+      >>>
+      >>> save_detector_masks('masks.h5', dg, entry_metadata=metadata)
+
+    Use ScippNexus to load the resulting file:
+
+      >>> import scippnexus.v2 as snx
+      >>>
+      >>> with snx.File('masks.h5') as f:
+      >>>     masks = f['entry'][()]
     """
     with h5py.File(filename, "w-") as f:
         entry = f.require_group("entry")

--- a/src/ess/masking.py
+++ b/src/ess/masking.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
+from pathlib import Path
+from typing import Union, Mapping
+import h5py
+import scipp as sc
+
+
+def save_detector_masks(
+    filename: Union[str, Path], detectors: Mapping[str, sc.DataArray]
+) -> None:
+    """
+    Save detector masks to an HDF5/NeXus file.
+
+    The masks will be saved inside an NXentry/NXinstrument group of the file.
+    An NXdetector group will be created for each detector.
+
+    Parameters
+    ----------
+    filename:
+        Name of the file to save to.
+    detectors:
+        Dictionary of data arrays whose masks should be saved.
+    """
+    with h5py.File(filename, "w-") as f:
+        entry = f.require_group("entry")
+        entry.attrs["NX_class"] = "NXentry"
+        instrument = entry.require_group("instrument")
+        instrument.attrs["NX_class"] = "NXinstrument"
+        for name, det in detectors.items():
+            _save_masks(instrument, detector_name=name, detector=det)
+
+
+def _save_masks(instrument, detector_name, detector):
+    group = instrument.create_group(detector_name)
+    group.attrs["NX_class"] = "NXdetector"
+    group.attrs["axes"] = ["."] * len(detector.dims)
+    for mask_name, mask in detector.masks.items():
+        ds = group.create_dataset(mask_name, data=mask.values)
+        group.attrs[f"{mask_name}_indices"] = [
+            detector.dims.index(dim) for dim in mask.dims
+        ]
+        for i, dim in enumerate(mask.dims):
+            ds.dims[i].label = dim

--- a/tests/masking_test.py
+++ b/tests/masking_test.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
+
+import pytest
+import tempfile
+import scipp as sc
+import scippnexus.v2 as snx
+from scipp.testing import assert_identical
+
+from ess.masking import save_detector_masks
+
+
+def roundtrip(obj):
+    with tempfile.TemporaryDirectory() as path:
+        name = f'{path}/test.hdf5'
+        save_detector_masks(name, obj)
+        with snx.File(name) as f:
+            return f[()]
+
+
+def test_save_detector_masks_rountrip():
+    dg = sc.DataGroup()
+    dg['det1'] = sc.DataArray(
+        data=sc.ones(dims=['x', 'y'], shape=[2, 2]),
+        masks={
+            'x': sc.array(dims=['x'], values=[True, False]),
+            'x2': sc.array(dims=['x'], values=[True, True]),
+            'y': sc.array(dims=['y'], values=[False, True]),
+        },
+    )
+    dg['det2'] = sc.DataArray(
+        data=sc.ones(dims=['x', 'y'], shape=[2, 2]),
+        masks={'yx': sc.array(dims=['y', 'x'], values=[[True, False], [False, True]])},
+    )
+    dg['det3'] = sc.DataArray(data=sc.ones(dims=['x', 'y'], shape=[2, 2]))
+    result = roundtrip(dg)
+    for name in dg:
+        assert_identical(
+            result['entry']['instrument'][name], sc.DataGroup(dg[name].masks)
+        )
+
+
+def test_save_detector_masks_does_not_overwrite():
+    dg = sc.DataGroup()
+    dg['det1'] = sc.DataArray(
+        data=sc.ones(dims=['x', 'y'], shape=[2, 2]),
+        masks={'x': sc.array(dims=['x'], values=[True, False])},
+    )
+    with tempfile.TemporaryDirectory() as path:
+        name = f'{path}/test.hdf5'
+        save_detector_masks(name, dg)
+        with pytest.raises(FileExistsError):
+            save_detector_masks(name, dg)

--- a/tests/masking_test.py
+++ b/tests/masking_test.py
@@ -1,8 +1,9 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 
-import pytest
 import tempfile
+
+import pytest
 import scipp as sc
 import scippnexus.v2 as snx
 from scipp.testing import assert_identical

--- a/tests/masking_test.py
+++ b/tests/masking_test.py
@@ -11,10 +11,10 @@ from scipp.testing import assert_identical
 from ess.masking import save_detector_masks
 
 
-def roundtrip(obj):
+def roundtrip(obj, **kwargs):
     with tempfile.TemporaryDirectory() as path:
         name = f'{path}/test.hdf5'
-        save_detector_masks(name, obj)
+        save_detector_masks(name, obj, **kwargs)
         with snx.File(name) as f:
             return f[()]
 
@@ -35,6 +35,23 @@ def test_save_detector_masks_rountrip():
     )
     dg['det3'] = sc.DataArray(data=sc.ones(dims=['x', 'y'], shape=[2, 2]))
     result = roundtrip(dg)
+    for name in dg:
+        assert_identical(
+            result['entry']['instrument'][name], sc.DataGroup(dg[name].masks)
+        )
+
+
+def test_save_detector_masks_metadata_roundtrip():
+    dg = sc.DataGroup()
+    dg['det'] = sc.DataArray(
+        data=sc.ones(dims=['x', 'y'], shape=[2, 2]),
+        masks={'x': sc.array(dims=['x'], values=[True, False])},
+    )
+    result = roundtrip(
+        dg, entry_metadata={'experiment_identifier': 12345, 'mycomment': 'abc'}
+    )
+    assert result['entry']['experiment_identifier'] == 12345
+    assert result['entry']['mycomment'] == 'abc'  # Not NeXus, but we are not strict
     for name in dg:
         assert_identical(
             result['entry']['instrument'][name], sc.DataGroup(dg[name].masks)


### PR DESCRIPTION
Related to https://confluence.esss.lu.se/display/DAM/DREAM+-+Save+mask+to+file. #176 will later use this to save masks created by users.

Note that this depends on ScippNexus features that have not been released yet, expect tests to fail on CI for now.