### PR TITLE
Use ScippNexus for Amor files

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -17,6 +17,7 @@ requirements:
     - matplotlib
     - pooch
     - scippneutron>=22.12.4
+    - scippnexus>=23.04.1
 
 test:
   imports:

--- a/docs/instruments/amor/amor_reduction.ipynb
+++ b/docs/instruments/amor/amor_reduction.ipynb
@@ -102,7 +102,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "bf511c93-d5a6-44fa-b349-22d18572a2a9",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "from orsopy import fileio\n",
@@ -201,7 +203,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "77bc292a-6cd9-4f55-9479-1b5b2c6b57ac",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "logger.info(\"Correcting pixel positions in 'sample.nxs'\")\n",
@@ -313,10 +317,12 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "ba03ff0f-0377-4e4f-8a0f-3f4c987c002c",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
-    "sample_wav.bins.concat('detector_id').hist(wavelength=200).plot()"
+    "sample_wav.bins.concat('detector_number').hist(wavelength=200).plot()"
    ]
   },
   {
@@ -490,7 +496,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "55daab88-10c1-4b2e-97de-b97e8317ad8e",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "q_edges = sc.geomspace(dim='Q', start=0.008, stop=0.075, num=200, unit='1/angstrom')\n",
@@ -504,8 +512,8 @@
     "\n",
     "pp.plot(\n",
     "    {\n",
-    "        'sample': sample_q.sum('detector_id'),\n",
-    "        'uncalibrated reference': reference_q.sum('detector_id'),\n",
+    "        'sample': sample_q.sum('detector_number'),\n",
+    "        'uncalibrated reference': reference_q.sum('detector_number'),\n",
     "    },\n",
     "    norm=\"log\",\n",
     ")"
@@ -539,7 +547,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "daf577ef-55c0-4556-aeb0-685a339db05e",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "reference_q_summed = reflectometry.conversions.sum_bins(reference_q)\n",
@@ -558,13 +568,15 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "a321a29b-3a6a-4ec4-ac35-fd8beb3474ea",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "pp.plot(\n",
     "    {\n",
-    "        'Uncalibrated': reference_q_summed.sum('detector_id'),\n",
-    "        'Calibrated': reference_q_summed_cal.sum('detector_id'),\n",
+    "        'Uncalibrated': reference_q_summed.sum('detector_number'),\n",
+    "        'Calibrated': reference_q_summed_cal.sum('detector_number'),\n",
     "    },\n",
     "    norm='log',\n",
     ")"
@@ -584,7 +596,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "6110caf5-4b88-4019-bea7-f07070413678",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "sample_q_summed = reflectometry.conversions.sum_bins(sample_q)\n",
@@ -645,10 +659,12 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "8b176b7b-e1e2-496b-8241-9a8203faac30",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
-    "normalized.mean('detector_id').plot(norm='log')"
+    "normalized.mean('detector_number').plot(norm='log')"
    ]
   },
   {
@@ -663,7 +679,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "11772c06-8541-4298-aac6-093f77d93ed8",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "normalized.coords['sigma_Q'] = amor.resolution.sigma_Q(\n",
@@ -753,7 +771,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sample_theta = sample_theta.bins.concat('detector_id')"
+    "sample_theta = sample_theta.bins.concat('detector_number')"
    ]
   },
   {
@@ -769,7 +787,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "466687c7-7603-40a5-ab8d-f3e23ecdab0a",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "nbins = 165\n",
@@ -784,11 +804,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "87ba276f-d15f-4f51-aafe-748544d5c65a",
-   "metadata": {},
+   "id": "6cc169b2-26ec-4890-aaff-7b563c916c70",
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
-    "binned.bins.sum().plot()"
+    "binned.hist().plot()"
    ]
   },
   {
@@ -835,7 +857,8 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3"
+   "pygments_lexer": "ipython3",
+   "version": "3.8.15"
   }
  },
  "nbformat": 4,

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ packages = find:
 install_requires =
     plopp>=22.12.1
     scippneutron>=22.11.0
+    scippnexus>=23.04.1
 python_requires = >=3.8
 include_package_data = True
 

--- a/src/ess/amor/load.py
+++ b/src/ess/amor/load.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Any, Optional, Union
 
 import scipp as sc
-import scippnexus as snx
+import scippnexus.v2 as snx
 
 from ..logging import get_logger
 from .beamline import make_beamline

--- a/src/ess/amor/load.py
+++ b/src/ess/amor/load.py
@@ -64,7 +64,6 @@ def _assemble_event_data(dg: sc.DataGroup) -> sc.DataArray:
     """
     events = dg['instrument']['multiblade_detector']
     events.bins.coords['tof'] = events.bins.coords.pop('event_time_offset')
-    del events.bins.coords['event_time_zero']
     events.coords['position'] = sc.spatial.as_vectors(
         events.coords.pop('x_pixel_offset'),
         events.coords.pop('y_pixel_offset'),

--- a/src/ess/amor/load.py
+++ b/src/ess/amor/load.py
@@ -50,6 +50,18 @@ def _tof_correction(data: sc.DataArray, dim: str = 'tof') -> sc.DataArray:
 
 
 def _assemble_event_data(dg: sc.DataGroup) -> sc.DataArray:
+    """Extract the events as a data array with all required coords.
+
+    Parameters
+    ----------
+    dg:
+        A data group with the structure of an Amor NeXus file.
+
+    Returns
+    -------
+    :
+        A data array with the events extracted from ``dg``.
+    """
     events = dg['instrument']['multiblade_detector']
     events.bins.coords['tof'] = events.bins.coords.pop('event_time_offset')
     del events.bins.coords['event_time_zero']
@@ -63,6 +75,7 @@ def _assemble_event_data(dg: sc.DataGroup) -> sc.DataArray:
 
 
 def _load_nexus_entry(filename: Union[str, Path]) -> sc.DataGroup:
+    """Load the single entry of a nexus file."""
     with snx.File(filename, 'r') as f:
         if len(f.keys()) != 1:
             raise snx.NexusStructureError(
@@ -76,8 +89,7 @@ def load(
     orso: Optional[Any] = None,
     beamline: Optional[dict] = None,
 ) -> sc.DataArray:
-    """
-    Loader for a single Amor data file.
+    """Load a single Amor data file.
 
     Parameters
     ----------
@@ -87,8 +99,6 @@ def load(
         The orso object to be populated by additional information from the loaded file.
     beamline:
         A dict defining the beamline parameters.
-    disable_warnings:
-        Do not show warnings from file loading if `True`. Default is `True`.
 
     Returns
     -------

--- a/src/ess/amor/load.py
+++ b/src/ess/amor/load.py
@@ -1,11 +1,11 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
-import warnings
 from datetime import datetime
-from typing import Any, Optional
+from pathlib import Path
+from typing import Any, Optional, Union
 
 import scipp as sc
-import scippneutron as scn
+import scippnexus as snx
 
 from ..logging import get_logger
 from .beamline import make_beamline
@@ -31,15 +31,16 @@ def _tof_correction(data: sc.DataArray, dim: str = 'tof') -> sc.DataArray:
     """
     if 'orso' in data.attrs:
         data.attrs['orso'].value.reduction.corrections += ['chopper ToF correction']
+    tof_unit = data.bins.constituents['data'].coords[dim].unit
     tau = sc.to_unit(
         1 / (2 * data.coords['source_chopper_2'].value['frequency'].data),
-        data.coords[dim].unit,
+        tof_unit,
     )
     chopper_phase = data.coords['source_chopper_2'].value['phase'].data
     tof_offset = tau * chopper_phase / (180.0 * sc.units.deg)
     # Make 2 bins, one for each pulse
     edges = sc.concat([-tof_offset, tau - tof_offset, 2 * tau - tof_offset], dim)
-    data = data.bin({dim: sc.to_unit(edges, data.coords[dim].unit)})
+    data = data.bin({dim: sc.to_unit(edges, tof_unit)})
     # Make one offset for each bin
     offset = sc.concat([tof_offset, tof_offset - tau], dim)
     # Apply the offset on both bins
@@ -48,11 +49,33 @@ def _tof_correction(data: sc.DataArray, dim: str = 'tof') -> sc.DataArray:
     return data.bin({dim: sc.concat([0.0 * sc.units.us, tau], dim)})
 
 
+def _assemble_event_data(dg: sc.DataGroup) -> sc.DataArray:
+    events = dg['instrument']['multiblade_detector']
+    events.bins.coords['tof'] = events.bins.coords.pop('event_time_offset')
+    del events.bins.coords['event_time_zero']
+    events.coords['position'] = sc.spatial.as_vectors(
+        events.coords.pop('x_pixel_offset'),
+        events.coords.pop('y_pixel_offset'),
+        events.coords.pop('z_pixel_offset'),
+    )
+    events.coords['sample_position'] = sc.vector([0, 0, 0], unit='m')
+    return events
+
+
+def _load_nexus_entry(filename: Union[str, Path]) -> sc.DataGroup:
+    with snx.File(filename, 'r') as f:
+        if len(f.keys()) != 1:
+            raise snx.NexusStructureError(
+                f"Expected a single entry in file {filename}, got {len(f.keys())}"
+            )
+        return f['entry'][()]
+
+
 def load(
-    filename,
+    filename: Union[str, Path],
     orso: Optional[Any] = None,
     beamline: Optional[dict] = None,
-    disable_warnings: Optional[bool] = True,
+    disable_warnings: Optional[bool] = True,  # TODO
 ) -> sc.DataArray:
     """
     Loader for a single Amor data file.
@@ -77,12 +100,8 @@ def load(
         "Loading '%s' as an Amor NeXus file",
         filename.filename if hasattr(filename, 'filename') else filename,
     )
-    if disable_warnings:
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", category=UserWarning)
-            data = scn.load_nexus(filename)
-    else:
-        data = scn.load_nexus(filename)
+    full_data = _load_nexus_entry(filename)
+    data = _assemble_event_data(full_data)
 
     # Recent versions of scippnexus no longer add variances for events by default, so
     # we add them here if they are missing.
@@ -92,12 +111,9 @@ def load(
         ].data.values
 
     # Convert tof nanoseconds to microseconds for convenience
-    # TODO: is it safe to assume that the dtype of the binned wrapper coordinate is
-    # the same as the dtype of the underlying event coordinate?
-    data.bins.coords['tof'] = data.bins.coords['tof'].astype('float64', copy=False)
-    data.coords['tof'] = data.coords['tof'].astype('float64', copy=False)
-    data.bins.coords['tof'] = sc.to_unit(data.bins.coords['tof'], 'us', copy=False)
-    data.coords['tof'] = sc.to_unit(data.coords['tof'], 'us', copy=False)
+    data.bins.coords['tof'] = data.bins.coords['tof'].to(
+        unit='us', dtype='float64', copy=False
+    )
 
     # Add beamline parameters
     beamline = make_beamline() if beamline is None else beamline
@@ -105,14 +121,14 @@ def load(
         data.coords[key] = value
 
     if orso is not None:
-        populate_orso(orso=orso, data=data, filename=filename)
+        populate_orso(orso=orso, data=full_data, filename=filename)
         data.attrs['orso'] = sc.scalar(orso)
 
     # Perform tof correction and fold two pulses
     return _tof_correction(data)
 
 
-def populate_orso(orso: Any, data: sc.DataArray, filename: str) -> Any:
+def populate_orso(orso: Any, data: sc.DataGroup, filename: str) -> Any:
     """
     Populate the Orso object, by calling the :code:`base_orso` and adding data from the
     file.
@@ -122,14 +138,15 @@ def populate_orso(orso: Any, data: sc.DataArray, filename: str) -> Any:
     orso:
         The orso object to be populated by additional information from the loaded file.
     data:
-        Data array to source information from.
+        Data group to source information from.
+        Should mimic the structure of the NeXus file.
     filename:
         Path of the file to load.
     """
-    orso.data_source.experiment.title = data.attrs['experiment_title'].value
-    orso.data_source.experiment.instrument = data.attrs['instrument_name'].value
+    orso.data_source.experiment.title = data['title']
+    orso.data_source.experiment.instrument = data['name']
     orso.data_source.experiment.start_date = datetime.strftime(
-        datetime.strptime(data.attrs['start_time'].value[:-3], '%Y-%m-%dT%H:%M:%S.%f'),
+        datetime.strptime(data['start_time'][:-3], '%Y-%m-%dT%H:%M:%S.%f'),
         '%Y-%m-%d',
     )
     orso.data_source.measurement.data_files = [filename]

--- a/src/ess/amor/load.py
+++ b/src/ess/amor/load.py
@@ -75,7 +75,6 @@ def load(
     filename: Union[str, Path],
     orso: Optional[Any] = None,
     beamline: Optional[dict] = None,
-    disable_warnings: Optional[bool] = True,  # TODO
 ) -> sc.DataArray:
     """
     Loader for a single Amor data file.

--- a/src/ess/amor/load.py
+++ b/src/ess/amor/load.py
@@ -31,7 +31,7 @@ def _tof_correction(data: sc.DataArray, dim: str = 'tof') -> sc.DataArray:
     """
     if 'orso' in data.attrs:
         data.attrs['orso'].value.reduction.corrections += ['chopper ToF correction']
-    tof_unit = data.bins.constituents['data'].coords[dim].unit
+    tof_unit = data.bins.coords[dim].bins.unit
     tau = sc.to_unit(
         1 / (2 * data.coords['source_chopper_2'].value['frequency'].data),
         tof_unit,

--- a/src/ess/amor/resolution.py
+++ b/src/ess/amor/resolution.py
@@ -132,4 +132,4 @@ def sigma_Q(
         angular_resolution**2
         + wavelength_resolution**2
         + sample_size_resolution**2
-    ).max('detector_id') * sc.midpoints(q_bins)
+    ).max('detector_number') * sc.midpoints(q_bins)

--- a/src/ess/reflectometry/conversions.py
+++ b/src/ess/reflectometry/conversions.py
@@ -250,5 +250,5 @@ def sum_bins(data_array: sc.DataArray):
     if 'angular_resolution' in data_array.bins.coords:
         data_array_summed.coords['angular_resolution'] = data_array.bins.coords[
             'angular_resolution'
-        ].max('detector_id')
+        ].max('detector_number')
     return data_array_summed

--- a/src/ess/reflectometry/conversions.py
+++ b/src/ess/reflectometry/conversions.py
@@ -97,13 +97,10 @@ def specular_reflection() -> dict:
     """
     graph = {
         **beamline.beamline(scatter=True),
-        **tof.elastic("tof"),
+        **tof.elastic_wavelength("tof"),
         "theta": theta,
         "Q": reflectometry_q,
     }
-    del graph['two_theta']
-    del graph['dspacing']
-    del graph['energy']
     return graph
 
 

--- a/src/ess/reflectometry/io.py
+++ b/src/ess/reflectometry/io.py
@@ -19,7 +19,7 @@ def save_ort(data_array: sc.DataArray, filename: str, dimension: str = None):
         String for dimension to perform mean over, defaults to 'detector_id'.
     """
     if dimension is None:
-        dimension = 'detector_id'
+        dimension = 'detector_number'
     from orsopy import fileio
 
     if filename[:-4] == '.ort':


### PR DESCRIPTION
As discussed it is unclear how we want to propagate metadata and store data in a workflow. This will likely need support by a future workflow framework. So for now, this PR only replaces `load_nexus` with using ScippNexus directly and puts the data into (almost) the same structure as before. At least, this will avoid the upcoming deprecation warning.