### PR TITLE
Do not install dependencies via pip during CI docs build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -65,7 +65,7 @@ jobs:
           environment-file: environment.yml
           cache-env: true
 
-      - run: python -m pip install .
+      - run: python -m pip install --no-deps .
       - run: jupyter --paths
       - run: python docs/make_docs.py --build-dir=html_${{ inputs.platform }}
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,7 @@ package_dir =
 packages = find:
 install_requires =
     plopp>=22.12.1
+    scipp>=22.11.0
     scippneutron>=22.11.0
     scippnexus>=23.04.1
 python_requires = >=3.8

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,6 @@ package_dir =
 packages = find:
 install_requires =
     plopp>=22.12.1
-    scipp>=22.11.0
     scippneutron>=22.11.0
     scippnexus>=23.04.1
 python_requires = >=3.8


### PR DESCRIPTION
During the Ci docs build, we first create a conda env with pinned package versions (e.g. scipp is pinned to 23.03.2).
The next step in the docs build is to `pip install .`, which looks at the dependencies in the `setup.cfg` and installs potentially newer versions from PyPi, thus rendering the pinning in the conda env useless.

By doing `pip install --no-deps .`, we avoid this and use the packages in the conda env. This will only install the local `ess` package.