### PR TITLE
Fix instrument view to not import plotting

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -16,7 +16,7 @@ requirements:
     - ipywidgets
     - matplotlib
     - pooch
-    - scippneutron>=22.12.4
+    - scippneutron>=23.09.0
     - scippnexus>=23.04.1
 
 test:

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,8 +25,8 @@ package_dir =
 packages = find:
 install_requires =
     plopp>=22.12.1
-    scipp>=23.07.0
-    scippneutron>=23.04.0
+    scipp>=23.08.0
+    scippneutron>=23.09.0
     scippnexus>=23.04.1
 python_requires = >=3.8
 include_package_data = True

--- a/src/ess/amor/instrument_view.py
+++ b/src/ess/amor/instrument_view.py
@@ -2,14 +2,13 @@
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 import scipp as sc
 import scippneutron as scn
-from scipp.plotting.objects import Plot
 
 from .beamline import instrument_view_components
 
 
 def instrument_view(
     da: sc.DataArray, components: dict = None, pixel_size: float = 0.0035, **kwargs
-) -> Plot:
+):
     """
     Instrument view for the Amor instrument, which automatically populates a list of
     additional beamline components, and sets the pixel size.

--- a/src/ess/external/powgen/instrument_view.py
+++ b/src/ess/external/powgen/instrument_view.py
@@ -4,7 +4,6 @@ from typing import Optional
 
 import scipp as sc
 import scippneutron as scn
-from scipp.plotting.objects import Plot
 
 
 def instrument_view(
@@ -13,7 +12,7 @@ def instrument_view(
     pixel_size: Optional[float] = None,
     components: Optional[dict] = None,
     **kwargs
-) -> Plot:
+):
     """
     Instrument view for the POWGEN instrument, with adjusted default arguments.
 


### PR DESCRIPTION
I removed the return annotation because `scn.instrument_view` has no annotation either.