### PR TITLE
Move doctrees for external instruments into common folder

### DIFF
--- a/docs/instruments/external/powgen/reference.rst
+++ b/docs/instruments/external/powgen/reference.rst
@@ -8,7 +8,7 @@ Modules
 
 .. autosummary::
    :template: ess-module-template.rst
-   :toctree: ../../generated
+   :toctree: ../../../generated
    :recursive:
 
    beamline


### PR DESCRIPTION
Previously, this would put the generated files for powgen into `docs/isntruments/generated` instead of `docs/generated`