### PR TITLE
Remove empty subpackages to avoid future headaches with namespace pkg

### DIFF
--- a/src/ess/beer/__init__.py
+++ b/src/ess/beer/__init__.py
@@ -1,2 +1,0 @@
-# SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2023 Scipp contributors (https://github.com/scipp)

--- a/src/ess/bifrost/__init__.py
+++ b/src/ess/bifrost/__init__.py
@@ -1,2 +1,0 @@
-# SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2023 Scipp contributors (https://github.com/scipp)

--- a/src/ess/cspec/__init__.py
+++ b/src/ess/cspec/__init__.py
@@ -1,2 +1,0 @@
-# SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2023 Scipp contributors (https://github.com/scipp)

--- a/src/ess/diffraction/singlecrystal/__init__.py
+++ b/src/ess/diffraction/singlecrystal/__init__.py
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
-"""
-Components for single crystal diffraction experiments.
-"""

--- a/src/ess/estia/__init__.py
+++ b/src/ess/estia/__init__.py
@@ -1,2 +1,0 @@
-# SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2023 Scipp contributors (https://github.com/scipp)

--- a/src/ess/freia/__init__.py
+++ b/src/ess/freia/__init__.py
@@ -1,2 +1,0 @@
-# SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2023 Scipp contributors (https://github.com/scipp)

--- a/src/ess/heimdal/__init__.py
+++ b/src/ess/heimdal/__init__.py
@@ -1,2 +1,0 @@
-# SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2023 Scipp contributors (https://github.com/scipp)

--- a/src/ess/magic/__init__.py
+++ b/src/ess/magic/__init__.py
@@ -1,2 +1,0 @@
-# SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2023 Scipp contributors (https://github.com/scipp)

--- a/src/ess/miracles/__init__.py
+++ b/src/ess/miracles/__init__.py
@@ -1,2 +1,0 @@
-# SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2023 Scipp contributors (https://github.com/scipp)

--- a/src/ess/nmx/__init__.py
+++ b/src/ess/nmx/__init__.py
@@ -1,2 +1,0 @@
-# SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2023 Scipp contributors (https://github.com/scipp)

--- a/src/ess/skadi/__init__.py
+++ b/src/ess/skadi/__init__.py
@@ -1,2 +1,0 @@
-# SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2023 Scipp contributors (https://github.com/scipp)

--- a/src/ess/trex/__init__.py
+++ b/src/ess/trex/__init__.py
@@ -1,2 +1,0 @@
-# SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2023 Scipp contributors (https://github.com/scipp)

--- a/src/ess/vespa/__init__.py
+++ b/src/ess/vespa/__init__.py
@@ -1,2 +1,0 @@
-# SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2023 Scipp contributors (https://github.com/scipp)


### PR DESCRIPTION
This is in preparation of making `ess*` packages namespace-packages. I am removing empty packages here, so after the next release we will be free to directly be created as namespace packages, without some sort of transition mechanism. In particular we may soon want to do this for `essnmx`.