### PR TITLE
Running SANS workflow without direct_beam

### DIFF
--- a/src/ess/sans/i_of_q.py
+++ b/src/ess/sans/i_of_q.py
@@ -315,9 +315,10 @@ def to_I_of_Q(
         }
 
     # Compute normalizing term
-    direct_beam = resample_direct_beam(
-        direct_beam=direct_beam, wavelength_bins=wavelength_bins
-    )
+    if direct_beam is not None:
+        direct_beam = resample_direct_beam(
+            direct_beam=direct_beam, wavelength_bins=wavelength_bins
+        )
     denominator = normalization.iofq_denominator(
         data=data,
         data_transmission_monitor=data_monitors['transmission'],


### PR DESCRIPTION
For debugging purposes it is useful to run workflow without direct_beam. This is simple fix should enable this by setting direct_beam = None
